### PR TITLE
Fixed the bug that the stop command could not close the JVM

### DIFF
--- a/src/main/java/com/javazilla/bukkitfabric/mixin/MixinDedicatedServer.java
+++ b/src/main/java/com/javazilla/bukkitfabric/mixin/MixinDedicatedServer.java
@@ -85,7 +85,6 @@ public abstract class MixinDedicatedServer extends MixinMinecraftServer {
     @Inject(at = @At("TAIL"), method = "exit")
     public void killProcess(CallbackInfo ci) {
         BukkitLogger.getLogger().info("Goodbye!");
-        System.exit(0);
     }
 
     /**


### PR DESCRIPTION
When you enter the stop command in the console, the server will shut down normally, the player will exit normally, and the world will be saved normally, but the JVM has been unable to exit.
After checking Thread Dump in debug mode, I found some possible causes

The stop command will call `net.minecraft.server.MinecraftServer#stop` and change running to false to interrupt the while loop in `net.minecraft.server.MinecraftServer#runServer`.
Then the runServer method will call `net.minecraft.server.MinecraftServer#shutdown` to close the netty connection and the server gui, and then call `net.minecraft.server.MinecraftServer#exit`. This method is modified by mixin and contains a line of `System. exit(0);`.

But there are several lines of code at the end of `net.minecraft.server.Main#main`:
```Java
            Thread thread = new Thread("Server Shutdown Thread") {
                public void run() {
                    minecraftDedicatedServer.stop(true);
                }
            };
            thread.setUncaughtExceptionHandler(new UncaughtExceptionLogger(LOGGER));
            Runtime.getRuntime().addShutdownHook(thread);
```
in other words:
The stop command calls `net.minecraft.server.MinecraftServer#stop`
`net.minecraft.server.MinecraftServer#stop` causes `net.minecraft.server.MinecraftServer#runServer` to call `net.minecraft.server.MinecraftServer#exit`

And `net.minecraft.server.MinecraftServer#exit` calls `System.exit(0);`
Then `System.exit(0);` calls `net.minecraft.server.MinecraftServer#stop` again
Then `net.minecraft.server.MinecraftServer#stop` calls `net.minecraft.server.MinecraftServer#exit`
...
This is an infinite recursion, but due to Thread, it does not trigger StackOverflowError.

In addition to deleting the `System.exit(0);` in `com.javazilla.bukkitfabric.mixin.MixinDedicatedServer#killProcess`, you can also use `java.lang.Runtime#removeShutdownHook` to delete the thread, but I I don't know the consequences of doing this.

```
Full thread dump

"Server thread@11049" prio=5 tid=0x24 nid=NA waiting
  java.lang.Thread.State: WAITING
at java.lang.Object.wait(Object.java:-1)
at java.lang.Thread.join(Thread.java:1252)
at java.lang.Thread.join(Thread.java:1326)
at java.lang.ApplicationShutdownHooks.runHooks(ApplicationShutdownHooks.java:107)
at java.lang.ApplicationShutdownHooks$1.run(ApplicationShutdownHooks.java:46)
at java.lang.Shutdown.runHooks(Shutdown.java:123)
at java.lang.Shutdown.sequence(Shutdown.java:170)
at java.lang.Shutdown.exit(Shutdown.java:216)
-locked <0x2f9> (a java.lang.Class)
at java.lang.Runtime.exit(Runtime.java:109)
at java.lang.System.exit(System.java:971)
at net.minecraft.server.dedicated.MinecraftDedicatedServer.handler$zza000$killProcess(MixinDedicatedServer.java:88)
at net.minecraft.server.dedicated.MinecraftDedicatedServer.exit(MinecraftDedicatedServer.java:299)
at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:708)
at net.minecraft.server.MinecraftServer.method_29739(MinecraftServer.java:254)
at net.minecraft.server.MinecraftServer$$Lambda$3352.1837840762.run(Unknown Source:-1)
at java.lang.Thread.run(Thread.java:748)

"Server Shutdown Thread@12927" prio=5 tid=0x2e nid=NA waiting
  java.lang.Thread.State: WAITING
at java.lang.Object.wait(Object.java:-1)
at java.lang.Thread.join(Thread.java:1252)
at java.lang.Thread.join(Thread.java:1326)
at net.minecraft.server.MinecraftServer.stop(MinecraftServer.java:633)
at net.minecraft.server.Main$1.run(Main.java:198)
```