### PR TITLE
Correcting invalid getMethod.

### DIFF
--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
@@ -336,7 +336,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
 
     @Override
     public boolean getAllowFlight() {
-        return CraftServer.server.isFlightEnabled();
+        return getHandle().abilities.allowFlying;
     }
 
     @Override


### PR DESCRIPTION
This was most likely not meant to be the servers allowFlight in the first place, as it is inside the CraftPlayer class.

Tryed this using Bssentials and this fixes its /fly command

(Also mind adding the "hacktoberfest" topic to this repository for it to be eligible for it :D)