### PR TITLE
build.gradle: shade extra dependencies into fat jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,12 +51,12 @@ dependencies {
     extraLibs group: "com.github.IsaiahPatton", name: "SpecialSource", version: "master-SNAPSHOT"
     extraLibs group: "com.github.phase", name: "SrgLib", version: "master-SNAPSHOT"
 
-    configurations.compile.extendsFrom(configurations.extraLibs)
+    extraLibs "com.google.code.gson:gson:2.8.0"
+    extraLibs "mysql:mysql-connector-java:5.1.48"
+    extraLibs "org.xerial:sqlite-jdbc:3.30.1"
+    extraLibs "org.yaml:snakeyaml:1.25"
 
-    implementation "com.google.code.gson:gson:2.8.0"
-    implementation "mysql:mysql-connector-java:5.1.48"
-    implementation "org.xerial:sqlite-jdbc:3.30.1"
-    implementation "org.yaml:snakeyaml:1.25"
+    configurations.compile.extendsFrom(configurations.extraLibs)
 }
 
 processResources {


### PR DESCRIPTION
Fixes logblock crashing on load due to mysql jdbc being missing.