### PR TITLE
Update README.md to it's correct state.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Cardboard is an implementation of the popular Bukkit/Spigot/Paper Modding API fo
 
 | Supported? | Minecraft       | Download      | Build Status |
 |-----------------|---------------------------|---------------|----------------------|
+| &#x274C; | Fabric 1.19.2 | Work-in-Progress |  |
 | &#x274C; | Fabric 1.18.2 | Work-in-Progress |  |
 | &#x2705; | Fabric 1.18.1 | [Download for 1.18.1](https://cardboardpowered.org/download/) | [![Build Status](https://img.shields.io/jenkins/build?jobUrl=https://ci.codemc.io/job/IsaiahPatton/job/Cardboard/&style=flat-square)](https://cardboardpowered.org/download) |
 | &#x2705; | Fabric 1.17.1 | [Download for 1.17.1](https://cardboardpowered.org/download) | [![Build Status](https://img.shields.io/jenkins/build?jobUrl=https://ci.codemc.io/job/IsaiahPatton/job/Cardboard/&style=flat-square)](https://cardboardpowered.org/download) |

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ SrgLib is also licensed under MIT.
 ## NMS Support
 We do support using Spigot's ``net.minecraft.server`` classes. 
 Classes and Fields will automatically remap to their intermediary counterparts *(Including Reflection!)*
-However, the current system is far from perfect and is currently [being rewritten](https://github.com/cardboardpowered/ingot/)
+However, the current system is far from perfect and is currently being rewritten.
 
 # Progress
 There is a progress indicator in the Discord. Although, if you're not in the Discord:


### PR DESCRIPTION
I deleted an broken link from README.md, and added an 1.19.2-wip field.