### PR TITLE
fix issue 471

### DIFF
--- a/src/main/java/org/cardboardpowered/mixin/network/handler/MixinSPNH_SignUpdateEvent.java
+++ b/src/main/java/org/cardboardpowered/mixin/network/handler/MixinSPNH_SignUpdateEvent.java
@@ -20,7 +20,6 @@ import net.minecraft.block.entity.SignBlockEntity;
 import net.minecraft.network.packet.c2s.play.UpdateSignC2SPacket;
 import net.minecraft.server.network.ServerPlayNetworkHandler;
 import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraft.text.LiteralTextContent;
 import net.minecraft.util.Formatting;
 
 @MixinInfo(events = {"SignChangeEvent"})

--- a/src/main/java/org/cardboardpowered/mixin/network/handler/MixinSPNH_SignUpdateEvent.java
+++ b/src/main/java/org/cardboardpowered/mixin/network/handler/MixinSPNH_SignUpdateEvent.java
@@ -43,7 +43,7 @@ public class MixinSPNH_SignUpdateEvent {
             String[] lines = new String[4];
     
             for (int i = 0; i < astring.length; ++i)
-                lines[i] = Formatting.strip(new LiteralTextContent (Formatting.strip(astring[i])).toString());
+                lines[i] = Formatting.strip(Formatting.strip(astring[i]));
     
             ((IMixinMinecraftServer)CraftServer.server).cardboard_runOnMainThread(() -> {
                 try {


### PR DESCRIPTION
Fix for issue #471 - string "literal{}"on signs

![no-fix-issue-471-cardboard](https://github.com/CardboardPowered/cardboard/assets/22984146/5f1a3010-4329-4ec7-bd8a-4dfca72eb7ac)
![no-fix-issue-471-cardboard-2](https://github.com/CardboardPowered/cardboard/assets/22984146/2af6fd5b-bda9-4860-b767-c366880b2689)

![fix-issue-471-cardboard](https://github.com/CardboardPowered/cardboard/assets/22984146/d10996d1-3d5d-40c5-ad3e-cf9ca51aa5cb)
![fix-issue-471-cardboard-2](https://github.com/CardboardPowered/cardboard/assets/22984146/0156e962-2205-4839-9788-8dc3dfd202ae)


Removed toString() conversion from the LiteralTextContent class that returned the sent text concatenated as follows:
"literal{" + text + "}"

This caused the bug reported in issue #471 