### PR TITLE
Fixed player teleportation to check if player switches between worlds

### DIFF
--- a/src/main/java/org/cardboardpowered/impl/entity/CraftPlayer.java
+++ b/src/main/java/org/cardboardpowered/impl/entity/CraftPlayer.java
@@ -226,6 +226,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkSectionPos;
 import net.minecraft.util.math.GlobalPos;
 import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.TeleportTarget;
 import net.minecraft.world.WorldProperties;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.network.packet.s2c.play.MapUpdateS2CPacket;
@@ -1396,14 +1397,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
         
         System.out.println("Hello! " + from.getWorld() + " / " + to.getWorld());
 
-        if (from.getWorld().equals(to.getWorld()))
-             ((IMixinPlayNetworkHandler)(Object)entity.networkHandler).teleport(to);
-        else {
-            //entity.moveToWorld(toWorld);
-            //entity.teleport
-            
-            ((IMixinPlayerManager)(PlayerManager)CraftServer.server.getPlayerManager()).moveToWorld(entity, toWorld, true, to, true);
-        }
+        Vec3d pos = new Vec3d(location.getX(), location.getY(), location.getZ());
+        Vec3d velocity = new Vec3d(0, 0, 0);
+        float yaw = location.getYaw();
+        float pitch = location.getPitch();
+
+        TeleportTarget target = new TeleportTarget(toWorld, pos, velocity, yaw, pitch, TeleportTarget.NO_OP);
+
+        this.getHandle().teleportTo(target);
 
         return true;
     }


### PR DESCRIPTION
# Fixed player teleportation to check if player switches between worlds.

When teleporting a player between two worlds (e.g. from nether to overworld), the code for handling the teleport teleports the player to the wrong coordinates making the world that the player is in go out of sync (client-side vs server-side).

This can be fixed by calling the NMS code `ServerPlayerEntity::teleportTo(...)` to make the Minecraft server handle the teleportation (the fix) instead of sending a packet manually (old implementation). The `ServerPlayerEntity::teleportTo()` already has a check if the player is in the same dimension or not and then performs the right teleportation logic.