### PR TITLE
Fixed error in item meta for shields that caused serialization to fail

### DIFF
--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
+++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
@@ -729,7 +729,6 @@ public final class CraftItemStack extends ItemStack {
             case DAYLIGHT_DETECTOR: 
             case HOPPER: 
             case COMPARATOR: 
-            case SHIELD: 
             case STRUCTURE_BLOCK: 
             case SHULKER_BOX: 
             case WHITE_SHULKER_BOX: 
@@ -772,6 +771,9 @@ public final class CraftItemStack extends ItemStack {
             // case VAULT:
             {
                 return new CraftMetaBlockState(item.getComponentChanges(), CraftItemType.minecraftToBukkit(item.getItem()), extraHandledDcts);
+            }
+            case SHIELD: {
+                return new CraftMetaShield(item.getComponentChanges(), extraHandledDcts);
             }
             case TROPICAL_FISH_BUCKET: {
             	return new CraftMetaItem(item.getComponentChanges(), extraHandledDcts);

--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
+++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
@@ -198,6 +198,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
                     // TODO .put(CraftMetaTropicalFishBucket.class, "TROPICAL_FISH_BUCKET")
                     .put(CraftMetaCrossbow.class, "CROSSBOW")
                     .put(CraftMetaSuspiciousStew.class, "SUSPICIOUS_STEW")
+                    .put(CraftMetaShield.class, "SHIELD")
                     .put(CraftMetaItem.class, "UNSPECIFIC")
                     .build();
 


### PR DESCRIPTION
Fixed error in item meta for shields that caused serialization to fail.

When creating ItemMeta for a shield (for example: on player death), the ItemMeta being created was `CraftMetaBlockState`, which should have been `CraftMetaShield`.

This cause errors when the shield has meta (for example: enchantments).
1. When the player dies, an error occurs.
2. When serializing a Bukkit ItemStack (of course a SHIELD having at least one enchantment) an error also occurs, for example when calling `toString()` on the itemstack (which calls `serialize()` interally).