### PR TITLE
Fix shulker boxes and chests staying open after the GUI is closed

### DIFF
--- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
@@ -337,7 +337,6 @@ public class CraftEventFactory {
     }
 
     public static com.mojang.datafixers.util.Pair<net.kyori.adventure.text.@Nullable Component, @Nullable AbstractContainerMenu> callInventoryOpenEventWithTitle(ServerPlayer player, AbstractContainerMenu container, boolean cancelled) {
-        ((AbstractContainerMenuBridge)container).cardboard$startOpen(); // delegate start open logic to before InventoryOpenEvent is fired
         if (player.containerMenu != player.inventoryMenu) { // fire INVENTORY_CLOSE if one already open
             player.connection.handleContainerClose(new ServerboundContainerClosePacket(player.containerMenu.containerId));
         }

--- a/src/main/java/org/cardboardpowered/bridge/world/inventory/AbstractContainerMenuBridge.java
+++ b/src/main/java/org/cardboardpowered/bridge/world/inventory/AbstractContainerMenuBridge.java
@@ -77,6 +77,4 @@ public interface AbstractContainerMenuBridge {
 
     default void cardboard$broadcastCarriedItem() {
     }
-
-    default void cardboard$startOpen() {}
 }

--- a/src/main/java/org/cardboardpowered/mixin/world/inventory/ChestMenuMixin.java
+++ b/src/main/java/org/cardboardpowered/mixin/world/inventory/ChestMenuMixin.java
@@ -49,11 +49,6 @@ public class ChestMenuMixin extends AbstractContainerMenuMixin {
         return bukkitEntity;
     }
 
-    @Override
-    public void cardboard$startOpen() {
-        this.container.startOpen(this.inventory.player);
-    }
-
     @Inject(method = "stillValid", at = @At("HEAD"), cancellable = true)
     public void stillValidCraftBukkit(Player player, CallbackInfoReturnable<Boolean> cir) {
         if (!this.checkReachable) cir.setReturnValue(true); // CraftBukkit

--- a/src/main/java/org/cardboardpowered/mixin/world/inventory/ShulkerBoxMenuMixin.java
+++ b/src/main/java/org/cardboardpowered/mixin/world/inventory/ShulkerBoxMenuMixin.java
@@ -38,11 +38,6 @@ public class ShulkerBoxMenuMixin extends AbstractContainerMenuMixin {
         return bukkitEntity;
     }
 
-    @Override
-    public void cardboard$startOpen() {
-        this.container.startOpen(this.inventory.player);
-    }
-
     @Inject(method = "stillValid", at = @At("HEAD"), cancellable = true)
     public void stillValidCraftBukkit(Player player, CallbackInfoReturnable<Boolean> cir) {
         if (!this.checkReachable) cir.setReturnValue(true); // CraftBukkit


### PR DESCRIPTION
Fixes #551

`startOpen` was being called twice per open, but `stopOpen` only once per close, so the opener count never got back to 0.

The `ChestMenu` and `ShulkerBoxMenu` constructors already call `container.startOpen(player)`. On top of that, `CraftEventFactory.callInventoryOpenEventWithTitle` called `cardboard$startOpen()`, which did the same thing again. `ServerPlayerMixin.openHandledScreen_c` constructs the menu before it fires the open event, so the vanilla call had already happened by then anyway — the extra hook wasn't buying anything, despite the comment claiming it needed to run before `InventoryOpenEvent`.

`ShulkerBoxBlockEntity` tracks viewers with a plain `private int openCount`. Two increments and one decrement leaves it at 1, which is still `> 0`, so the lid never retracts and the collision box stays expanded. That's the reported symptom, and it's permanent.

Chests have the same double-count but present differently. `ChestBlockEntity` delegates to `ContainerOpenersCounter`, and `openerCountChanged` calls `scheduleRecheck`, which schedules a block tick five ticks out (`level.scheduleTick(pos, block, 5)`). When that recheck runs it recounts viewers from scratch via `getEntitiesWithContainerOpen(...).size()` and overwrites the count. Because it's a scheduled one-shot rather than a continuous recount, the correction lands some of the time and not others — chests were observed sticking open roughly half the time. Shulker boxes have no equivalent recheck at all, which is why the bug reads as permanent there and intermittent on chests.

Removed the `cardboard$startOpen` hook and its two overrides (`ChestMenuMixin`, `ShulkerBoxMenuMixin`). Nothing else overrode it — everything else inherited the no-op default — so this only affects chests and shulkers, both of which already call `startOpen` in their constructors.

This also fixes a leak on the cancel path: `ServerPlayerMixin.openHandledScreen_c` calls `stopOpen` once when a plugin cancels `InventoryOpenEvent`, which was one short of the two increments. Cancelling an open on a shulker box wedged it the same way.

Tested on a live server: shulker boxes, chests, double chests, multiple simultaneous viewers, disconnecting while open, and breaking the block while open.
