### PR TITLE
Fix AbstractMethodError crash from minecart container inventories

### DIFF
--- a/src/main/java/org/cardboardpowered/bridge/world/ContainerBridge.java
+++ b/src/main/java/org/cardboardpowered/bridge/world/ContainerBridge.java
@@ -23,16 +23,27 @@ public interface ContainerBridge {
     default void onOpen(CraftHumanEntity who) {
     }
 
-    void onClose(CraftHumanEntity who);
+    // These are defaulted rather than abstract because MixinContainer grafts this
+    // interface onto every net.minecraft.world.Container. Any container class
+    // without a dedicated mixin would otherwise throw AbstractMethodError at the
+    // first call site, which callers cannot catch.
+    default void onClose(CraftHumanEntity who) {
+    }
 
-    java.util.List<org.bukkit.entity.HumanEntity> getViewers();
+    default java.util.List<org.bukkit.entity.HumanEntity> getViewers() {
+        return java.util.Collections.emptyList();
+    }
 
-  
-    org.bukkit.inventory.InventoryHolder getOwner();
+    default org.bukkit.inventory.InventoryHolder getOwner() {
+        return null;
+    }
 
-    void cardboard$setMaxStackSize(int size);
+    default void cardboard$setMaxStackSize(int size) {
+    }
 
-    org.bukkit.Location getLocation();
+    default org.bukkit.Location getLocation() {
+        return null;
+    }
 
     default Recipe<?> getCurrentRecipe() {
         return null;

--- a/src/main/java/org/cardboardpowered/mixin/world/entity/vehicle/minecart/AbstractMinecartContainerMixin.java
+++ b/src/main/java/org/cardboardpowered/mixin/world/entity/vehicle/minecart/AbstractMinecartContainerMixin.java
@@ -1,0 +1,68 @@
+package org.cardboardpowered.mixin.world.entity.vehicle.minecart;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.minecraft.world.Container;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.vehicle.minecart.AbstractMinecartContainer;
+import net.minecraft.world.item.ItemStack;
+import org.bukkit.Location;
+import org.bukkit.craftbukkit.entity.CraftHumanEntity;
+import org.bukkit.entity.HumanEntity;
+import org.bukkit.inventory.InventoryHolder;
+import org.spongepowered.asm.mixin.Mixin;
+
+import org.cardboardpowered.bridge.world.ContainerBridge;
+import org.cardboardpowered.bridge.world.entity.EntityBridge;
+import org.cardboardpowered.bridge.world.level.LevelBridge;
+
+@Mixin(AbstractMinecartContainer.class)
+public abstract class AbstractMinecartContainerMixin implements Container, ContainerBridge {
+
+    public List<HumanEntity> transaction = new ArrayList<>();
+    private int maxStack = MAX_STACK;
+
+    @Override
+    public List<ItemStack> getContents() {
+        return ((AbstractMinecartContainer)(Object)this).getItemStacks();
+    }
+
+    @Override
+    public InventoryHolder getOwner() {
+        org.bukkit.entity.Entity entity = ((EntityBridge)this).getBukkitEntity();
+        return (entity instanceof InventoryHolder) ? (InventoryHolder) entity : null;
+    }
+
+    @Override
+    public void onOpen(CraftHumanEntity who) {
+        transaction.add(who);
+    }
+
+    @Override
+    public void onClose(CraftHumanEntity who) {
+        transaction.remove(who);
+    }
+
+    @Override
+    public List<HumanEntity> getViewers() {
+        return transaction;
+    }
+
+    @Override
+    public void cardboard$setMaxStackSize(int size) {
+        maxStack = size;
+    }
+
+    @Override
+    public int getMaxStackSize() {
+        return maxStack;
+    }
+
+    @Override
+    public Location getLocation() {
+        Entity entity = (Entity)(Object)this;
+        return new Location(((LevelBridge)entity.level()).cardboard$getWorld(), entity.getX(), entity.getY(), entity.getZ());
+    }
+
+}

--- a/src/main/resources/bukkitfabric.mixins.json
+++ b/src/main/resources/bukkitfabric.mixins.json
@@ -113,6 +113,7 @@
     "world.entity.player.InventoryMixin",
     "world.entity.player.PlayerMixin",
     "world.entity.projectile.FireworkRocketEntityMixin",
+    "world.entity.vehicle.minecart.AbstractMinecartContainerMixin",
     "world.entity.projectile.ProjectileMixin",
     "world.entity.projectile.arrow.AbstractArrowMixin",
     "world.entity.projectile.arrow.ArrowMixin",


### PR DESCRIPTION
Fixes #571

A hopper minecart picking up a dropped item crashes the server. Once the minecart sits in a chunk a player loads on login, the server crash-loops and is unusable.

```
java.lang.AbstractMethodError: Method net/minecraft/world/entity/vehicle/minecart/MinecartHopper.getOwner()Lorg/bukkit/inventory/InventoryHolder; is abstract
        at net.minecraft.world.level.block.entity.HopperBlockEntity.handler$zga000$cardboard$extract1(HopperBlockEntity.java:602)
        at net.minecraft.world.entity.vehicle.minecart.MinecartHopper.suckInItems(MinecartHopper.java:111)
        at net.minecraft.world.entity.vehicle.minecart.MinecartHopper.tick(MinecartHopper.java:91)
```

## Cause

`MixinContainer` grafts `ContainerBridge` onto every `net.minecraft.world.Container`. `ContainerBridge.getOwner()` was abstract with no default, and `AbstractMinecartContainer` had no mixin implementing it — there was no `mixin/world/entity/vehicle/` package at all.

`HopperBlockEntityMixin.extract1` guards on `iinventory instanceof ContainerBridge`, which passes for a hopper minecart because the minecart is the container. It then calls `getOwner()`, which has no implementation, and the JVM throws `AbstractMethodError`. The hook's `catch (NullPointerException)` doesn't stop it, since `AbstractMethodError` is an `Error` rather than an `Exception`, so it propagates out of `guardEntityTick` and takes the server down.

## Changes

**`AbstractMinecartContainerMixin`** (new) implements `ContainerBridge` for minecart containers. `getOwner()` returns the Bukkit entity, so `InventoryPickupItemEvent` now fires with the correct holder for hopper and chest minecarts rather than throwing. Registered in `bukkitfabric.mixins.json`.

**`ContainerBridge`** — the remaining abstract members (`onClose`, `getViewers`, `getOwner`, `cardboard$setMaxStackSize`, `getLocation`) now have defaults. Because the interface is grafted onto every `Container`, any container class without a dedicated mixin is otherwise a latent `AbstractMethodError` at the first call site, and callers can't defend against it. Defaulting them turns a server crash into a no-op for containers that haven't been implemented yet.

## Notes

This is independent of #570 and touches no shared files.

Reproduced on both the Modrinth release and a local build of `ver/26.1`, then confirmed fixed on a live server — hopper minecarts pick up items normally and the crash-loop is gone.

Worth flagging separately: nine of the thirteen current `getOwner()` implementations return `null`, so `InventoryPickupItemEvent` NPEs into `extract1`'s catch block on every hopper pickup and effectively never fires for block containers. That's a larger behavioural fix and is deliberately not addressed here. #303 and #266 look like the null-returning variant of the same root cause.
