### PR TITLE
Fix shulker boxes and chests staying open after the GUI is closed (1.21.11)

### DIFF
--- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
@@ -337,7 +337,6 @@ public class CraftEventFactory {
     }
 
     public static com.mojang.datafixers.util.Pair<net.kyori.adventure.text.@Nullable Component, @Nullable AbstractContainerMenu> callInventoryOpenEventWithTitle(ServerPlayer player, AbstractContainerMenu container, boolean cancelled) {
-        ((AbstractContainerMenuBridge)container).cardboard$startOpen(); // delegate start open logic to before InventoryOpenEvent is fired
         if (player.containerMenu != player.inventoryMenu) { // fire INVENTORY_CLOSE if one already open
             player.connection.handleContainerClose(new ServerboundContainerClosePacket(player.containerMenu.containerId));
         }

--- a/src/main/java/org/cardboardpowered/bridge/world/inventory/AbstractContainerMenuBridge.java
+++ b/src/main/java/org/cardboardpowered/bridge/world/inventory/AbstractContainerMenuBridge.java
@@ -77,6 +77,4 @@ public interface AbstractContainerMenuBridge {
 
     default void cardboard$broadcastCarriedItem() {
     }
-
-    default void cardboard$startOpen() {}
 }

--- a/src/main/java/org/cardboardpowered/mixin/world/inventory/ChestMenuMixin.java
+++ b/src/main/java/org/cardboardpowered/mixin/world/inventory/ChestMenuMixin.java
@@ -49,11 +49,6 @@ public class ChestMenuMixin extends AbstractContainerMenuMixin {
         return bukkitEntity;
     }
 
-    @Override
-    public void cardboard$startOpen() {
-        this.container.startOpen(this.inventory.player);
-    }
-
     @Inject(method = "stillValid", at = @At("HEAD"), cancellable = true)
     public void stillValidCraftBukkit(Player player, CallbackInfoReturnable<Boolean> cir) {
         if (!this.checkReachable) cir.setReturnValue(true); // CraftBukkit

--- a/src/main/java/org/cardboardpowered/mixin/world/inventory/ShulkerBoxMenuMixin.java
+++ b/src/main/java/org/cardboardpowered/mixin/world/inventory/ShulkerBoxMenuMixin.java
@@ -38,11 +38,6 @@ public class ShulkerBoxMenuMixin extends AbstractContainerMenuMixin {
         return bukkitEntity;
     }
 
-    @Override
-    public void cardboard$startOpen() {
-        this.container.startOpen(this.inventory.player);
-    }
-
     @Inject(method = "stillValid", at = @At("HEAD"), cancellable = true)
     public void stillValidCraftBukkit(Player player, CallbackInfoReturnable<Boolean> cir) {
         if (!this.checkReachable) cir.setReturnValue(true); // CraftBukkit


### PR DESCRIPTION
Backport of #570 (`ec6ca0ec`) to `ver/1.21.11`. Original patch and investigation by @Johndpete316 — cherry-picked with `-x`, authorship preserved. Same issue as #551, on this branch.

## The bug is present here too, unchanged

`startOpen` is called twice per open but `stopOpen` only once per close, so the opener count never returns to 0. All three redundant call sites exist on `ver/1.21.11` in the same shape:

| File | |
|---|---|
| `CraftEventFactory.java:340` | `((AbstractContainerMenuBridge)container).cardboard$startOpen();` |
| `AbstractContainerMenuBridge.java:81` | `default void cardboard$startOpen() {}` |
| `ChestMenuMixin.java:53` | override calling `container.startOpen(...)` |
| `ShulkerBoxMenuMixin.java:42` | same |

## The premise holds on vanilla 1.21.11

Checked against the official 1.21.11 server jar (obfuscation resolved through Mojang's mappings):

- `ChestMenu(MenuType, int, Inventory, Container, int)` already calls `Container#startOpen(ContainerUser)` in its constructor (offset 34).
- `ShulkerBoxMenu(int, Inventory, Container)` does the same (offset 24).
- `ShulkerBoxBlockEntity` still tracks viewers with a plain `int openCount`, so the off-by-one is permanent there — the lid never retracts and the collision box stays expanded.
- `ChestBlockEntity` still delegates to `ContainerOpenersCounter` with its five-tick `scheduleRecheck`, which is why chests present as intermittently rather than permanently stuck.

The cancel path is also identical: `ServerPlayerMixin` (lines 339/341) calls `stopOpen` once against the two increments when a plugin cancels `InventoryOpenEvent`, so backporting fixes that leak here as well.

## Change

Pure deletion — 4 files, 13 removals, 0 additions. The cherry-pick applied without conflicts, and no reference to `cardboard$startOpen` remains in the tree.

## Testing

Not yet built or run in game on this branch — flagging that openly rather than implying otherwise. The upstream change was tested on a live 26.1 server against shulker boxes, chests, double chests, multiple simultaneous viewers, disconnecting while open, and breaking the block while open; the same matrix is what this needs on 1.21.11. Happy to hold until someone confirms.