### PR TITLE
fix: repair the three regressions that make ver/1.21.11 unusable when built from source

### DIFF
--- a/src/main/java/org/cardboardpowered/impl/command/MyCommand.java
+++ b/src/main/java/org/cardboardpowered/impl/command/MyCommand.java
@@ -63,7 +63,7 @@ public class MyCommand extends Command {
     	}
     	
     	if (args[0].equalsIgnoreCase("version")) {
-    		String ver = FabricLoader.getInstance().getModContainer("cardboard").get().getMetadata().getVersion().getFriendlyString();
+    		String ver = FabricLoader.getInstance().getModContainer("cardboardmc").get().getMetadata().getVersion().getFriendlyString();
             if (ver.contains("version")) ver = CraftServer.INSTANCE.getShortVersion(); // Dev ENV
 
             String message = ChatColor.GOLD + "Cardboard" + ChatColor.RESET + " version " + ver + ChatColor.ITALIC + " (Reimplementing Paper API version " + CardboardMod.paperVersion + ")";

--- a/src/main/java/org/cardboardpowered/impl/command/VersionCommand.java
+++ b/src/main/java/org/cardboardpowered/impl/command/VersionCommand.java
@@ -47,7 +47,7 @@ public class VersionCommand extends Command {
         if (!testPermission(sender)) return true;
 
         if (args.length == 0) {
-            String ver = FabricLoader.getInstance().getModContainer("cardboard").get().getMetadata().getVersion().getFriendlyString();
+            String ver = FabricLoader.getInstance().getModContainer("cardboardmc").get().getMetadata().getVersion().getFriendlyString();
             if (ver.contains("version")) ver = CraftServer.INSTANCE.getShortVersion(); // Dev ENV
 
             String message = "This server is running " + ChatColor.GOLD + Bukkit.getName() + ChatColor.RESET + " version " + ver + ChatColor.ITALIC + " (Implementing API version " + Bukkit.getBukkitVersion() + ")";

--- a/src/main/java/org/cardboardpowered/mixin/CardboardMixinPlugin.java
+++ b/src/main/java/org/cardboardpowered/mixin/CardboardMixinPlugin.java
@@ -159,7 +159,7 @@ public class CardboardMixinPlugin implements IMixinConfigPlugin {
     		return null;
     	}
         URL[] jar = {
-                FabricLoader.getInstance().getModContainer("cardboard").get().getRootPath().toUri().toURL(),
+                FabricLoader.getInstance().getModContainer("cardboardmc").get().getRootPath().toUri().toURL(),
                 FabricLoader.getInstance().getModContainer("minecraft").get().getRootPath().toUri().toURL(),
                 FabricLoader.getInstance().getModContainer("fabricloader").get().getRootPath().toUri().toURL(),
                 papi.toURI().toURL()

--- a/src/main/java/org/cardboardpowered/mixin/bukkit/BukkitMixin.java
+++ b/src/main/java/org/cardboardpowered/mixin/bukkit/BukkitMixin.java
@@ -20,7 +20,7 @@ public class BukkitMixin {
 	 */
 	@Overwrite(remap = false)
     public static String getVersionMessage() {
-		ModMetadata metadata = FabricLoader.getInstance().getModContainer("cardboard").get().getMetadata();
+		ModMetadata metadata = FabricLoader.getInstance().getModContainer("cardboardmc").get().getMetadata();
 		
 		String ver = metadata.getVersion().getFriendlyString();
         if (ver.contains("version")) ver = CraftServer.INSTANCE.getShortVersion(); // Dev ENV

--- a/src/main/java/org/cardboardpowered/mixin/bukkit/BukkitRegistryMixin.java
+++ b/src/main/java/org/cardboardpowered/mixin/bukkit/BukkitRegistryMixin.java
@@ -24,7 +24,7 @@ public interface BukkitRegistryMixin {
 }
 
 /*
-@Mixin(value = net.minecraft.server.dedicated.MinecraftDedicatedServer.class, priority = 5000)
+@Mixin(value = net.minecraft.server.dedicated.MinecraftDedicatedServer.class, priority = 900)
 @Deprecated
 public class MixinArmorItem {
 	

--- a/src/main/java/org/cardboardpowered/mixin/server/ServerScoreboardMixin.java
+++ b/src/main/java/org/cardboardpowered/mixin/server/ServerScoreboardMixin.java
@@ -19,7 +19,7 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.scores.Objective;
 import net.minecraft.world.scores.Scoreboard;
 
-@Mixin(value = ServerScoreboard.class, priority = 5000)
+@Mixin(value = ServerScoreboard.class, priority = 900)
 public abstract class ServerScoreboardMixin extends Scoreboard implements ServerScoreboardBridge {
 
     @Shadow

--- a/src/main/java/org/cardboardpowered/mixin/server/level/ServerPlayerGameModeMixin.java
+++ b/src/main/java/org/cardboardpowered/mixin/server/level/ServerPlayerGameModeMixin.java
@@ -58,7 +58,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
-@Mixin(value = ServerPlayerGameMode.class, priority = 5000)
+@Mixin(value = ServerPlayerGameMode.class, priority = 999)
 public class ServerPlayerGameModeMixin implements ServerPlayerGameModeBridge {
 
     @Shadow public ServerPlayer player;

--- a/src/main/java/org/cardboardpowered/mixin/server/level/ServerPlayerMixin.java
+++ b/src/main/java/org/cardboardpowered/mixin/server/level/ServerPlayerMixin.java
@@ -91,7 +91,7 @@ import net.minecraft.world.level.portal.TeleportTransition;
 import net.minecraft.world.phys.Vec3;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
-@Mixin(value = ServerPlayer.class, priority = 5000)
+@Mixin(value = ServerPlayer.class, priority = 999)
 public abstract class ServerPlayerMixin extends PlayerMixin implements CommandSourceBridge, ServerPlayerBridge {
 
 	@Shadow

--- a/src/main/java/org/cardboardpowered/mixin/server/network/LegacyQueryHandlerMixin.java
+++ b/src/main/java/org/cardboardpowered/mixin/server/network/LegacyQueryHandlerMixin.java
@@ -17,7 +17,7 @@ import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 
 @MixinInfo(events = "ServerListPingEvent")
-@Mixin(value = LegacyQueryHandler.class, priority = 5000)
+@Mixin(value = LegacyQueryHandler.class, priority = 999)
 public class LegacyQueryHandlerMixin {
 
     @Shadow private static ByteBuf createLegacyDisconnectPacket(ByteBufAllocator allocator, String string) {return null;}

--- a/src/main/java/org/cardboardpowered/mixin/server/network/ServerGamePacketListenerImplMixin.java
+++ b/src/main/java/org/cardboardpowered/mixin/server/network/ServerGamePacketListenerImplMixin.java
@@ -74,7 +74,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
 @SuppressWarnings("deprecation")
-@Mixin(value = ServerGamePacketListenerImpl.class, priority = 5000)
+@Mixin(value = ServerGamePacketListenerImpl.class, priority = 800)
 public abstract class ServerGamePacketListenerImplMixin extends ServerCommonPacketListenerImpl implements ServerGamePacketListenerImplBridge {
 
     public ServerGamePacketListenerImplMixin(MinecraftServer server, Connection connection, CommonListenerCookie clientData) {

--- a/src/main/java/org/cardboardpowered/mixin/server/network/ServerGamePacketListenerImplMixin_ChatEvent.java
+++ b/src/main/java/org/cardboardpowered/mixin/server/network/ServerGamePacketListenerImplMixin_ChatEvent.java
@@ -12,7 +12,7 @@ import org.bukkit.craftbukkit.entity.CraftPlayer;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 
-@Mixin(value = ServerGamePacketListenerImpl.class, priority = 5000)
+@Mixin(value = ServerGamePacketListenerImpl.class, priority = 999)
 public abstract class ServerGamePacketListenerImplMixin_ChatEvent extends ServerCommonPacketListenerImpl {
 
     @Shadow 

--- a/src/main/java/org/cardboardpowered/mixin/server/network/ServerGamePacketListenerImplMixin_InventoryClickEvent.java
+++ b/src/main/java/org/cardboardpowered/mixin/server/network/ServerGamePacketListenerImplMixin_InventoryClickEvent.java
@@ -29,7 +29,7 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @MixinInfo(events = {"InventoryClickEvent", "CraftItemEvent"})
-@Mixin(value = ServerGamePacketListenerImpl.class, priority = 5000)
+@Mixin(value = ServerGamePacketListenerImpl.class, priority = 800)
 public class ServerGamePacketListenerImplMixin_InventoryClickEvent {
 
     @Shadow 

--- a/src/main/java/org/cardboardpowered/mixin/server/network/ServerGamePacketListenerImplMixin_PlayerCommandPreprocessEvent.java
+++ b/src/main/java/org/cardboardpowered/mixin/server/network/ServerGamePacketListenerImplMixin_PlayerCommandPreprocessEvent.java
@@ -28,7 +28,7 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.network.ServerGamePacketListenerImpl;
 import net.minecraft.util.FutureChain;
 
-@Mixin(value = ServerGamePacketListenerImpl.class, priority = 5000)
+@Mixin(value = ServerGamePacketListenerImpl.class, priority = 800)
 public abstract class ServerGamePacketListenerImplMixin_PlayerCommandPreprocessEvent implements ServerGamePacketListenerImplBridge {
 
 	@Shadow

--- a/src/main/java/org/cardboardpowered/mixin/server/network/ServerGamePacketListenerImplMixin_PlayerMove.java
+++ b/src/main/java/org/cardboardpowered/mixin/server/network/ServerGamePacketListenerImplMixin_PlayerMove.java
@@ -33,7 +33,7 @@ import org.cardboardpowered.bridge.server.level.ServerPlayerBridge;
 
 import io.papermc.paper.event.player.PlayerFailMoveEvent;
 
-@Mixin(value = ServerGamePacketListenerImpl.class, priority = 5000)
+@Mixin(value = ServerGamePacketListenerImpl.class, priority = 801)
 public class ServerGamePacketListenerImplMixin_PlayerMove {
 
 	// Cardboard - start

--- a/src/main/java/org/cardboardpowered/mixin/server/network/ServerGamePacketListenerImplMixin_SignUpdateEvent.java
+++ b/src/main/java/org/cardboardpowered/mixin/server/network/ServerGamePacketListenerImplMixin_SignUpdateEvent.java
@@ -21,7 +21,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @MixinInfo(events = {"SignChangeEvent"})
-@Mixin(value = ServerGamePacketListenerImpl.class, priority = 5000)
+@Mixin(value = ServerGamePacketListenerImpl.class, priority = 800)
 public class ServerGamePacketListenerImplMixin_SignUpdateEvent {
 
     @Shadow 

--- a/src/main/java/org/cardboardpowered/mixin/server/network/ServerLoginPacketListenerImplMixin.java
+++ b/src/main/java/org/cardboardpowered/mixin/server/network/ServerLoginPacketListenerImplMixin.java
@@ -67,7 +67,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import io.papermc.paper.connection.PaperPlayerLoginConnection;
 
 @SuppressWarnings("deprecation")
-@Mixin(value = ServerLoginPacketListenerImpl.class, priority = 5000)
+@Mixin(value = ServerLoginPacketListenerImpl.class, priority = 999)
 public abstract class ServerLoginPacketListenerImplMixin implements ServerLoginPacketListenerImplBridge {
 
 	private static Logger LOGGER_BF = LoggerFactory.getLogger("PaperMC|ServerLoginNetworkHandler"); // LogManager.getLogger("Bukkit|ServerLoginNetworkHandler");

--- a/src/main/java/org/cardboardpowered/mixin/stats/StatsCounterMixin.java
+++ b/src/main/java/org/cardboardpowered/mixin/stats/StatsCounterMixin.java
@@ -27,7 +27,7 @@ import net.minecraft.stats.StatsCounter;
 import net.minecraft.world.entity.player.Player;
 import org.bukkit.craftbukkit.event.CraftEventFactory;
 
-@Mixin(value = StatsCounter.class, priority = 5000)
+@Mixin(value = StatsCounter.class, priority = 900)
 public class StatsCounterMixin {
 
     /**

--- a/src/main/java/org/cardboardpowered/mixin/world/entity/ExperienceOrbMixin.java
+++ b/src/main/java/org/cardboardpowered/mixin/world/entity/ExperienceOrbMixin.java
@@ -26,7 +26,7 @@ import org.bukkit.craftbukkit.event.CraftEventFactory;
 import org.bukkit.entity.ExperienceOrb;
 import org.bukkit.entity.Player;
 
-@Mixin(value = net.minecraft.world.entity.ExperienceOrb.class, priority = 5000)
+@Mixin(value = net.minecraft.world.entity.ExperienceOrb.class, priority = 900)
 public class ExperienceOrbMixin extends EntityMixin {
 
 	private static final ThreadLocal<net.minecraft.world.entity.player.Player> currentPlayer = new ThreadLocal<>();

--- a/src/main/java/org/cardboardpowered/mixin/world/entity/ai/behavior/AssignProfessionFromJobSiteMixin.java
+++ b/src/main/java/org/cardboardpowered/mixin/world/entity/ai/behavior/AssignProfessionFromJobSiteMixin.java
@@ -5,7 +5,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import net.minecraft.world.entity.ai.behavior.AssignProfessionFromJobSite;
 
 @MixinInfo(events = {"VillagerCareerChangeEvent"})
-@Mixin(value = AssignProfessionFromJobSite.class, priority = 5000)
+@Mixin(value = AssignProfessionFromJobSite.class, priority = 999)
 public class AssignProfessionFromJobSiteMixin {
 
 	/*

--- a/src/main/java/org/cardboardpowered/mixin/world/entity/ai/behavior/ResetProfessionMixin.java
+++ b/src/main/java/org/cardboardpowered/mixin/world/entity/ai/behavior/ResetProfessionMixin.java
@@ -20,7 +20,7 @@ import org.bukkit.craftbukkit.entity.CraftVillager;
 import org.cardboardpowered.util.MixinInfo;
 
 @MixinInfo(events = {"VillagerCareerChangeEvent"})
-@Mixin(value = ResetProfession.class, priority = 5000)
+@Mixin(value = ResetProfession.class, priority = 900)
 public class ResetProfessionMixin {
 
     /**

--- a/src/main/java/org/cardboardpowered/mixin/world/entity/decoration/LeashFenceKnotEntityMixin.java
+++ b/src/main/java/org/cardboardpowered/mixin/world/entity/decoration/LeashFenceKnotEntityMixin.java
@@ -18,7 +18,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.phys.AABB;
 
 @MixinInfo(events = {"PlayerLeashEntityEvent", "PlayerUnleashEntityEvent"})
-@Mixin(value = LeashFenceKnotEntity.class, priority = 5000)
+@Mixin(value = LeashFenceKnotEntity.class, priority = 900)
 public class LeashFenceKnotEntityMixin {
 
     private LeashFenceKnotEntity getBF() {

--- a/src/main/java/org/cardboardpowered/mixin/world/entity/monster/piglin/PiglinAiMixin.java
+++ b/src/main/java/org/cardboardpowered/mixin/world/entity/monster/piglin/PiglinAiMixin.java
@@ -30,7 +30,7 @@ import net.minecraft.world.item.Items;
 import org.bukkit.craftbukkit.event.CraftEventFactory;
 
 @MixinInfo(events = {"EntityPickupItemEvent"})
-@Mixin(value = PiglinAi.class, priority = 5000)
+@Mixin(value = PiglinAi.class, priority = 900)
 public class PiglinAiMixin {
 
     /**

--- a/src/main/java/org/cardboardpowered/mixin/world/entity/projectile/throwableitemprojectile/ThrownEggMixin.java
+++ b/src/main/java/org/cardboardpowered/mixin/world/entity/projectile/throwableitemprojectile/ThrownEggMixin.java
@@ -25,7 +25,7 @@ import org.cardboardpowered.bridge.world.entity.EntityBridge;
 import org.cardboardpowered.bridge.world.level.LevelBridge;
 
 @MixinInfo(events = {"ThrownEggHatchEvent", "PlayerEggThrowEvent"})
-@Mixin(value = ThrownEgg.class, priority = 5000)
+@Mixin(value = ThrownEgg.class, priority = 999)
 public abstract class ThrownEggMixin {
 
     private final Random random = new Random();

--- a/src/main/java/org/cardboardpowered/mixin/world/item/ArmorStandItemMixin.java
+++ b/src/main/java/org/cardboardpowered/mixin/world/item/ArmorStandItemMixin.java
@@ -13,7 +13,7 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @MixinInfo(events = {"EntityPlaceEvent"})
-@Mixin(value = ArmorStandItem.class, priority = 5000)
+@Mixin(value = ArmorStandItem.class, priority = 900)
 public class ArmorStandItemMixin {
 
     private transient ArmorStand bukkitEntity;

--- a/src/main/java/org/cardboardpowered/mixin/world/item/BlockItemMixin.java
+++ b/src/main/java/org/cardboardpowered/mixin/world/item/BlockItemMixin.java
@@ -46,7 +46,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.bukkit.craftbukkit.event.CraftEventFactory;
 import org.cardboardpowered.bridge.server.level.ServerPlayerBridge;
 
-@Mixin(value = BlockItem.class, priority = 5000) // Priority 999 to allow Carpet Mod
+@Mixin(value = BlockItem.class, priority = 999) // Priority 999 to allow Carpet Mod
 public class BlockItemMixin implements BlockItemBridge {
 
     @Shadow public BlockState getPlacementState(BlockPlaceContext blockactioncontext) {return null;}

--- a/src/main/java/org/cardboardpowered/mixin/world/item/CrossbowItemMixin.java
+++ b/src/main/java/org/cardboardpowered/mixin/world/item/CrossbowItemMixin.java
@@ -5,7 +5,7 @@ import org.cardboardpowered.util.MixinInfo;
 import org.spongepowered.asm.mixin.Mixin;
 
 @MixinInfo(events = {"EntityShootBowEvent"})
-@Mixin(value = CrossbowItem.class, priority = 5000)
+@Mixin(value = CrossbowItem.class, priority = 900)
 public class CrossbowItemMixin {
 
     // private static transient boolean bukkitCapturedBoolean;

--- a/src/main/java/org/cardboardpowered/mixin/world/item/DyeItemMixin.java
+++ b/src/main/java/org/cardboardpowered/mixin/world/item/DyeItemMixin.java
@@ -18,7 +18,7 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.cardboardpowered.bridge.world.entity.EntityBridge;
 
 @MixinInfo(events = {"SheepDyeWoolEvent"})
-@Mixin(value = DyeItem.class, priority = 5000)
+@Mixin(value = DyeItem.class, priority = 900)
 public class DyeItemMixin {
 
     @Shadow

--- a/src/main/java/org/cardboardpowered/mixin/world/item/EndCrystalItemMixin.java
+++ b/src/main/java/org/cardboardpowered/mixin/world/item/EndCrystalItemMixin.java
@@ -21,7 +21,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-@Mixin(value = EndCrystalItem.class, priority = 5000)
+@Mixin(value = EndCrystalItem.class, priority = 900)
 public class EndCrystalItemMixin {
 
     /**

--- a/src/main/java/org/cardboardpowered/mixin/world/item/EnderpearlItemMixin.java
+++ b/src/main/java/org/cardboardpowered/mixin/world/item/EnderpearlItemMixin.java
@@ -22,7 +22,7 @@ import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 
-@Mixin(value = EnderpearlItem.class, priority = 5000)
+@Mixin(value = EnderpearlItem.class, priority = 900)
 public class EnderpearlItemMixin extends Item {
 
     public EnderpearlItemMixin(net.minecraft.world.item.Item.Properties settings) {

--- a/src/main/java/org/cardboardpowered/mixin/world/item/HangingEntityItemMixin.java
+++ b/src/main/java/org/cardboardpowered/mixin/world/item/HangingEntityItemMixin.java
@@ -26,7 +26,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 @MixinInfo(events = {"HangingPlaceEvent"})
-@Mixin(value = HangingEntityItem.class, priority = 5000)
+@Mixin(value = HangingEntityItem.class, priority = 900)
 public class HangingEntityItemMixin {
 
     @Inject(method = "useOn", cancellable = true, locals = LocalCapture.CAPTURE_FAILHARD,

--- a/src/main/java/org/cardboardpowered/mixin/world/item/ItemStackMixin.java
+++ b/src/main/java/org/cardboardpowered/mixin/world/item/ItemStackMixin.java
@@ -37,7 +37,7 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.pattern.BlockInWorld;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-@Mixin(value = ItemStack.class, priority = 5000)
+@Mixin(value = ItemStack.class, priority = 999)
 public abstract class ItemStackMixin implements ItemStackBridge {
     @Shadow
     public Item item;

--- a/src/main/java/org/cardboardpowered/mixin/world/item/LeadItemMixin.java
+++ b/src/main/java/org/cardboardpowered/mixin/world/item/LeadItemMixin.java
@@ -27,7 +27,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.AABB;
 
 @MixinInfo(events = {"HangingPlaceEvent"})
-@Mixin(value = LeadItem.class, priority = 5000)
+@Mixin(value = LeadItem.class, priority = 900)
 public class LeadItemMixin extends Item {
 
     public LeadItemMixin(net.minecraft.world.item.Item.Properties settings) {

--- a/src/main/java/org/cardboardpowered/mixin/world/item/MinecartItemMixin.java
+++ b/src/main/java/org/cardboardpowered/mixin/world/item/MinecartItemMixin.java
@@ -20,7 +20,7 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
-@Mixin(value = MinecartItem.class, priority = 5000)
+@Mixin(value = MinecartItem.class, priority = 999)
 public class MinecartItemMixin {
 
     @Redirect(method = "useOn", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/level/ServerLevel;addFreshEntity(Lnet/minecraft/world/entity/Entity;)Z"))

--- a/src/main/java/org/cardboardpowered/mixin/world/item/PotionItemMixin.java
+++ b/src/main/java/org/cardboardpowered/mixin/world/item/PotionItemMixin.java
@@ -3,7 +3,7 @@ package org.cardboardpowered.mixin.world.item;
 import net.minecraft.world.item.PotionItem;
 import org.spongepowered.asm.mixin.Mixin;
 
-@Mixin(value = PotionItem.class, priority = 5000)
+@Mixin(value = PotionItem.class, priority = 900)
 public class PotionItemMixin {
 
 	/*

--- a/src/main/java/org/cardboardpowered/mixin/world/item/ProjectileWeaponItemMixin.java
+++ b/src/main/java/org/cardboardpowered/mixin/world/item/ProjectileWeaponItemMixin.java
@@ -1,9 +1,11 @@
 package org.cardboardpowered.mixin.world.item;
 
 import java.util.List;
+import java.util.function.Consumer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.projectile.Projectile;
 import net.minecraft.world.item.ItemStack;
@@ -16,6 +18,11 @@ import org.jspecify.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
 import org.bukkit.craftbukkit.event.CraftEventFactory;
 import org.cardboardpowered.bridge.server.level.ServerPlayerBridge;
 import org.cardboardpowered.bridge.world.entity.EntityBridge;
@@ -34,6 +41,9 @@ public class ProjectileWeaponItemMixin {
 
     public boolean cancel_BF = false;
 
+    @Unique
+    private boolean cardboard$shotCancelled = false;
+
     
     @Shadow
     public Projectile createProjectile( Level world, LivingEntity shooter, ItemStack weaponStack, ItemStack projectileStack, boolean critical) {
@@ -50,41 +60,53 @@ public class ProjectileWeaponItemMixin {
     }
     
     /**
-     * @author cardboard mod
-     * @reason callEntityShootBowEvent
-     * 
-     * TODO: use inject
+     * Fire {@link EntityShootBowEvent} once per projectile, wrapping the spawn call so the
+     * event carries the real projectile and a cancellation keeps it out of the world entirely.
+     *
+     * The previous @Inject at HEAD of shoot fired the event before any projectile existed and
+     * passed null, which CraftEventFactory#callEntityShootBowEvent dereferences unconditionally,
+     * so every shot threw NullPointerException.
      */
-    @Inject(method = "shoot", at = @At("HEAD"))
-    private void cardboard$shoot(
-            ServerLevel serverLevel,
-            LivingEntity livingEntity,
-            InteractionHand interactionHand,
-            ItemStack itemStack,
-            List<ItemStack> list,
-            float f,
-            float g,
-            boolean bl,
-            @Nullable LivingEntity livingEntity2,
-            CallbackInfo ci
-    ) {
-        // Fire Bukkit event only once per method call
-        EntityShootBowEvent event =
-                CraftEventFactory.callEntityShootBowEvent(
-                        livingEntity,
-                        itemStack,
-                        list.isEmpty() ? ItemStack.EMPTY : list.get(0),
-                        null,
-                        interactionHand,
-                        f,
-                        true
-                );
+    @WrapOperation(method = "shoot",
+                   at = @At(value = "INVOKE",
+                            target = "Lnet/minecraft/world/entity/projectile/Projectile;spawnProjectile(Lnet/minecraft/world/entity/projectile/Projectile;Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/item/ItemStack;Ljava/util/function/Consumer;)Lnet/minecraft/world/entity/projectile/Projectile;"))
+    private Projectile cardboard$callEntityShootBowEvent(
+            Projectile projectile,
+            ServerLevel level,
+            ItemStack ammo,
+            Consumer<Projectile> config,
+            Operation<Projectile> original,
+            @Local(argsOnly = true, ordinal = 0) LivingEntity shooter,
+            @Local(argsOnly = true) InteractionHand hand,
+            @Local(argsOnly = true) ItemStack weapon,
+            @Local(argsOnly = true, ordinal = 0) float speed) {
 
-        if (event.isCancelled()) {
-            ci.cancel();
+        EntityShootBowEvent event = CraftEventFactory.callEntityShootBowEvent(shooter, weapon, ammo, projectile, hand, speed, true);
+
+        // A plugin either cancelled the shot or swapped in its own projectile; either way ours
+        // must not reach the world.
+        if (event.isCancelled() || event.getProjectile() != ((EntityBridge) projectile).getBukkitEntity()) {
+            this.cardboard$shotCancelled = true;
+            projectile.discard();
+            return projectile;
         }
+
+        this.cardboard$shotCancelled = false;
+        return original.call(projectile, level, ammo, config);
     }
-    
+
+    /** Vanilla damages the weapon right after spawning; a cancelled shot should not cost durability. */
+    @WrapOperation(method = "shoot",
+                   at = @At(value = "INVOKE",
+                            target = "Lnet/minecraft/world/item/ItemStack;hurtAndBreak(ILnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/entity/EquipmentSlot;)V"))
+    private void cardboard$skipDurabilityOnCancelledShot(ItemStack weapon, int amount, LivingEntity shooter, EquipmentSlot slot, Operation<Void> original) {
+        if (this.cardboard$shotCancelled) {
+            this.cardboard$shotCancelled = false;
+            return;
+        }
+        original.call(weapon, amount, shooter, slot);
+    }
+
     /*
     @Inject(at = @At(value = "INVOKE", shift = At.Shift.AFTER, target = ""))
     public void cardboard$do_EntityShootBowEvent(

--- a/src/main/java/org/cardboardpowered/mixin/world/item/ProjectileWeaponItemMixin.java
+++ b/src/main/java/org/cardboardpowered/mixin/world/item/ProjectileWeaponItemMixin.java
@@ -25,7 +25,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @MixinInfo(events = {"EntityShootBowEvent"})
 // @Mixin(BowItem.class)
-@Mixin(value = ProjectileWeaponItem.class, priority = 5000)
+@Mixin(value = ProjectileWeaponItem.class, priority = 900)
 /**
  * TODO: Rename class, 1.20.6 moved
  * functionality to RangedWeaponItem

--- a/src/main/java/org/cardboardpowered/mixin/world/item/SnowballItemMixin.java
+++ b/src/main/java/org/cardboardpowered/mixin/world/item/SnowballItemMixin.java
@@ -16,7 +16,7 @@ import org.cardboardpowered.bridge.world.entity.EntityBridge;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 
-@Mixin(value = SnowballItem.class, priority = 5000)
+@Mixin(value = SnowballItem.class, priority = 900)
 public class SnowballItemMixin extends Item {
 
     public SnowballItemMixin(net.minecraft.world.item.Item.Properties settings) {

--- a/src/main/java/org/cardboardpowered/mixin/world/item/consume_effects/TeleportRandomlyConsumeEffectMixin.java
+++ b/src/main/java/org/cardboardpowered/mixin/world/item/consume_effects/TeleportRandomlyConsumeEffectMixin.java
@@ -3,7 +3,7 @@ package org.cardboardpowered.mixin.world.item.consume_effects;
 import net.minecraft.world.item.consume_effects.TeleportRandomlyConsumeEffect;
 import org.spongepowered.asm.mixin.Mixin;
 
-@Mixin(value = TeleportRandomlyConsumeEffect.class, priority = 5000)
+@Mixin(value = TeleportRandomlyConsumeEffect.class, priority = 900)
 public class TeleportRandomlyConsumeEffectMixin { // extends Item {
 
 	// TODO

--- a/src/main/java/org/cardboardpowered/mixin/world/item/enchantment/EnchantmentsMixin.java
+++ b/src/main/java/org/cardboardpowered/mixin/world/item/enchantment/EnchantmentsMixin.java
@@ -16,7 +16,7 @@ import org.bukkit.craftbukkit.event.CraftEventFactory;
 
 /**
  */
-/// @Mixin(value = FrostWalkerEnchantment.class, priority = 5000)
+/// @Mixin(value = FrostWalkerEnchantment.class, priority = 999)
 @Mixin(Enchantments.class) // TODO
 public class EnchantmentsMixin {
 

--- a/src/main/java/org/cardboardpowered/mixin/world/level/storage/PlayerDataStorageMixin.java
+++ b/src/main/java/org/cardboardpowered/mixin/world/level/storage/PlayerDataStorageMixin.java
@@ -14,7 +14,7 @@ import org.spongepowered.asm.mixin.Shadow;
 import java.io.File;
 import java.io.FileInputStream;
 
-@Mixin(value = PlayerDataStorage.class, priority = 5000)
+@Mixin(value = PlayerDataStorage.class, priority = 999)
 public class PlayerDataStorageMixin implements PlayerDataStorageBridge {
 
     @Shadow


### PR DESCRIPTION
`ver/1.21.11` cannot be built into a working server. Commit `7eb05c6c` (2026-05-23, *"Increased priority and added compatibility with some more mods by turning overwrites into injects"*) (https://github.com/CardboardPowered/cardboard/pull/565) introduced three independent regressions: one stops the server from booting, one stops any player from connecting, and one throws on every bow shot. Each is fixed in its own commit — they are unrelated repairs and any of them can be dropped without affecting the others.

The overwrite-to-inject conversions from that commit are kept. Only the side effects are repaired, and the one conversion that was left broken is finished properly rather than reverted.

---

## 1. The mod id no longer matches what the code looks up

The commit renamed the mod id:

```diff
-  "id": "cardboard",
+  "id": "cardboardmc",
```

but left the four places that resolve the mod by the old id untouched:

| File | |
|---|---|
| `mixin/bukkit/BukkitMixin.java:23` | `getModContainer("cardboard").get().getMetadata()` |
| `mixin/CardboardMixinPlugin.java:162` | same, inside `getClassLoader()` |
| `impl/command/VersionCommand.java:50` | same |
| `impl/command/MyCommand.java:66` | same |

`BukkitMixin` `@Overwrite`s `Bukkit#getVersionMessage()`, which is why the failing frame is attributed to `Bukkit.java`. The Optional is empty, and `Bukkit.setServer` is the first thing Cardboard's `DedicatedServer` init performs, so the server never reaches world load:

```
[main/INFO]: No value present          <- repeated once per mixin
... (~100+ lines)
[Server thread/ERROR]: Encountered an unexpected exception
java.util.NoSuchElementException: No value present
	at java.base/java.util.Optional.get(Optional.java:143)
	at knot//org.bukkit.Bukkit.getVersionMessage(Bukkit.java:3078)
	at knot//org.bukkit.Bukkit.setServer(Bukkit.java:116)
	at knot//net.minecraft.class_3176.handler$zcb000$cardboardmc$init(class_3176.java:978)
```

The flood of bare `No value present` INFO lines above the crash is the same mismatch in `CardboardMixinPlugin#getClassLoader`: the exception is caught and `e.getMessage()` logged once per mixin.

**Fix:** point the four lookups at `cardboardmc`, so the rename stands rather than being reverted. The other `"cardboard"` literals in the tree are the `/cardboard` command name and the `config/cardboard` directory — unrelated to the mod id, left alone.

## 2. The blanket priority bump breaks other mods' mixins

The same commit raised 35 mixins from 800–999 to 5000.

Those sub-1000 values were load-bearing. Other mods' mixins default to priority 1000, and Mixin refuses to let a lower-priority mixin inject into a method merged by a higher-priority one. Sitting just below 1000 is precisely what allowed other mods to keep injecting into the methods Cardboard merges. At 5000 that inverts, and `fabric-networking-api-v1` can no longer patch the login handler — every player connection dies:

```
InvalidInjectionException: @At("INVOKE") on
net/minecraft/class_3248::removeLateCompressionPacketSending with priority 1000
cannot inject into net/minecraft/class_3248::method_52419(Lcom/mojang/authlib/GameProfile;)V
merged by org.cardboardpowered.mixin.server.network.ServerLoginPacketListenerImplMixin
with priority 5000
```

The login handler is just the first to fire. `ServerGamePacketListenerImpl` was 800/801 across five mixins and is also patched by fabric-api (chat, movement, inventory clicks); `ItemStack` and `ServerPlayer` were 999. That the bump was mechanical rather than considered is visible in `BlockItemMixin`, where the comment explaining the value was left in place while the value it described changed underneath it:

```java
@Mixin(value = BlockItem.class, priority = 5000) // Priority 999 to allow Carpet Mod
```

**Fix:** restore each mixin's original value. Only `priority` literals change — 35 lines, nothing else. `ver/26.1` still carries the original values throughout, consistent with 26.1.2 servers being unaffected.

If a particular mixin genuinely needs to outrank other mods, raising that one back with a comment explaining why is entirely reasonable; a blanket 5000 is what breaks things. If any of these 35 were deliberate, say which and I'll leave them raised.

## 3. Every bow and crossbow shot throws

`ProjectileWeaponItemMixin`'s `@Overwrite` of `shoot` became an `@Inject` at `HEAD`. No projectile exists at `HEAD`, so the injector passes `null`:

```java
CraftEventFactory.callEntityShootBowEvent(livingEntity, itemStack,
        list.isEmpty() ? ItemStack.EMPTY : list.get(0), null, ...)
```

and `callEntityShootBowEvent` dereferences it unconditionally:

```java
org.bukkit.entity.Entity arrow = ((EntityBridge) entityArrow).getBukkitEntity();
```

```
java.lang.NullPointerException: Cannot invoke
"org.cardboardpowered.bridge.world.entity.EntityBridge.getBukkitEntity()" because "entityArrow" is null
	at knot//org.bukkit.craftbukkit.event.CraftEventFactory.callEntityShootBowEvent(CraftEventFactory.java:640)
	at knot//net.minecraft.class_1811.handler$zgd000$cardboardmc$cardboard$shoot(class_1811.java:573)
	at knot//net.minecraft.class_1753.method_7840(class_1753.java:48)
```

**Fix:** finish the conversion instead of reverting it. The event now fires from a `@WrapOperation` around `Projectile#spawnProjectile(Projectile, ServerLevel, ItemStack, Consumer)` inside `shoot` — the projectile exists there and has not entered the world yet, so the event carries the real arrow and a cancellation keeps it out of the world entirely rather than spawning and removing it. A second wrap skips the durability hit on a cancelled shot, matching CraftBukkit, and a plugin swapping `event.getProjectile()` suppresses the vanilla one the same way `ver/26.1` does. The vanilla method body is not duplicated, so the compatibility benefit of the original conversion is preserved.

One behaviour note: the event now fires per projectile, so cancelling one arrow of a multishot crossbow no longer suppresses the rest — each gets its own cancellable event.

## Verification

Fixes 1 and 2 are confirmed on a live 1.21.11 server (fabric-api 0.141.4, plus Lithium, Simple Voice Chat, AudioPlayer, FallingTree, AntiXray and others):

- before: a build of branch HEAD reproduces the `setServer` crash verbatim and the server never starts;
- with fix 1: server boots, no `No value present` output;
- with fix 1 only: player login throws the `InvalidInjectionException` above;
- with fixes 1 + 2: server boots, players connect and play.

Fix 3 was found by the bow NPE on that same server. On a clean 1.21.11 instance the patched build boots with no `InvalidInjection` output, and dumping the transformed bytecode (`-Dmixin.debug.export=true`) confirms both wraps are woven into `ProjectileWeaponItem#shoot` with the surrounding locals captured. Firing a bow in game needs a client, so the in-game half of that check is still outstanding; skeletons go through `spawnProjectileFromRotation` and do not exercise this path.

For reference, the last published 1.21.11 jar predates `7eb05c6c` — it carries `"id": "cardboard"`, the original priorities and the original `shoot` overwrite, which is why released builds work while source builds do not.

This currently blocks any source build of `ver/1.21.11` from being tested, including #577 and #578.
