### PR TITLE
fix: stop lecterns throwing ClassCastException when opened (1.21.11)

### DIFF
--- a/src/main/java/org/cardboardpowered/bridge/world/inventory/LecternMenuBridge.java
+++ b/src/main/java/org/cardboardpowered/bridge/world/inventory/LecternMenuBridge.java
@@ -1,0 +1,17 @@
+package org.cardboardpowered.bridge.world.inventory;
+
+import org.bukkit.entity.Player;
+
+/**
+ * API Interface for LecternMenu
+ *
+ * <p>Vanilla's {@code LecternMenu} constructor only receives the lectern's own container, so the
+ * viewing player has to be handed to it separately once {@code LecternBlockEntity#createMenu} knows
+ * who is opening it.
+ *
+ * @implNote https://github.com/PaperMC/Paper/blob/main/paper-server/patches/sources/net/minecraft/world/inventory/LecternMenu.java.patch
+ */
+public interface LecternMenuBridge {
+
+    void setPlayer(Player player);
+}

--- a/src/main/java/org/cardboardpowered/mixin/world/inventory/LecternMenuMixin.java
+++ b/src/main/java/org/cardboardpowered/mixin/world/inventory/LecternMenuMixin.java
@@ -1,7 +1,6 @@
 package org.cardboardpowered.mixin.world.inventory;
 
 import net.minecraft.world.Container;
-import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.ContainerData;
 import net.minecraft.world.inventory.LecternMenu;
@@ -15,13 +14,11 @@ import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-
-import org.cardboardpowered.bridge.world.entity.EntityBridge;
+import org.cardboardpowered.bridge.world.inventory.LecternMenuBridge;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(LecternMenu.class)
-public class LecternMenuMixin extends AbstractContainerMenuMixin {
+public class LecternMenuMixin extends AbstractContainerMenuMixin implements LecternMenuBridge {
 
     @Shadow
     public Container lectern;
@@ -32,9 +29,9 @@ public class LecternMenuMixin extends AbstractContainerMenuMixin {
     private CraftInventoryView bukkitEntity = null;
     private org.bukkit.entity.Player player;
 
-    @Inject(method = "<init>(ILnet/minecraft/world/Container;Lnet/minecraft/world/inventory/ContainerData;)V", at = @At("TAIL"))
-    public void setPlayerInv(int i, Container iinventory, ContainerData icontainerproperties, CallbackInfo ci) {
-        this.player = (org.bukkit.entity.Player)((EntityBridge)((Inventory)iinventory).player).getBukkitEntity();
+    @Override
+    public void setPlayer(org.bukkit.entity.Player player) {
+        this.player = player;
     }
 
     @Override

--- a/src/main/java/org/cardboardpowered/mixin/world/level/block/entity/LecternBlockEntityMixin.java
+++ b/src/main/java/org/cardboardpowered/mixin/world/level/block/entity/LecternBlockEntityMixin.java
@@ -1,0 +1,28 @@
+package org.cardboardpowered.mixin.world.level.block.entity;
+
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.level.block.entity.LecternBlockEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import org.cardboardpowered.bridge.world.entity.EntityBridge;
+import org.cardboardpowered.bridge.world.inventory.LecternMenuBridge;
+
+@Mixin(LecternBlockEntity.class)
+public class LecternBlockEntityMixin {
+
+    /**
+     * The lectern menu is built from the lectern's own container, so it never sees who opened it.
+     * Hand the viewer over here, where it is known.
+     */
+    @Inject(method = "createMenu", at = @At("RETURN"))
+    public void setPlayer(int i, Inventory playerinventory, Player entityhuman, CallbackInfoReturnable<AbstractContainerMenu> cir) {
+        if (cir.getReturnValue() instanceof LecternMenuBridge menu) {
+            menu.setPlayer((org.bukkit.entity.Player) ((EntityBridge) entityhuman).getBukkitEntity());
+        }
+    }
+}

--- a/src/main/resources/bukkitfabric.mixins.json
+++ b/src/main/resources/bukkitfabric.mixins.json
@@ -207,6 +207,7 @@
     "world.level.block.entity.ChestBlockEntityMixin",
     "world.level.block.entity.DispenserBlockEntityMixin",
     "world.level.block.entity.HopperBlockEntityMixin",
+    "world.level.block.entity.LecternBlockEntityMixin",
     "world.level.block.entity.ShulkerBoxBlockEntityMixin",
     "world.level.block.entity.SignBlockEntityMixin",
     "world.level.block.entity.TheEndGatewayBlockEntityMixin",


### PR DESCRIPTION
Opening a lectern that holds a book throws a `ClassCastException` on the server, so the reading screen never opens.

## How to reproduce

No plugin needed, reproduces 100% of the time on a stock Cardboard server:

1. Join the server and place a lectern.
2. Right-click it holding a written book or a book and quill. The book goes in (`has_book=true`) — this step is fine.
3. Right-click the lectern again **with an empty hand**.

The screen does not open and the console logs:

```
[Server thread/ERROR]: Failed to handle packet net.minecraft.class_2885@79d3bf4a, suppressing error
java.lang.ClassCastException: class net.minecraft.class_3722$1 cannot be cast to class net.minecraft.class_1661
	at knot//net.minecraft.class_3916.handler$zfc000$cardboardmc$setPlayerInv(class_3916.java:537)
	at knot//net.minecraft.class_3916.<init>(class_3916.java:40)
	at knot//net.minecraft.class_3722.createMenu(class_3722.java:242)
	at knot//net.minecraft.class_3222.handler$zcf000$cardboardmc$openHandledScreen_c(class_3222.java:2762)
	...
```

The empty hand matters: `LecternBlock#useWithoutItem` is the only path that calls `openScreen`, so holding an item that has its own interaction never reaches the bug. That is probably why it went unnoticed.

Nothing crashes — the exception is swallowed by the packet handler, so from the player's side the lectern simply does nothing.

## Why it happens

`LecternMenuMixin` injected into the menu constructor and cast its `Container` argument to the player `Inventory`:

```java
@Inject(method = "<init>(ILnet/minecraft/world/Container;Lnet/minecraft/world/inventory/ContainerData;)V", at = @At("TAIL"))
public void setPlayerInv(int i, Container iinventory, ContainerData icontainerproperties, CallbackInfo ci) {
    this.player = (org.bukkit.entity.Player)((EntityBridge)((Inventory)iinventory).player).getBukkitEntity();
}
```

That cast can never succeed. Vanilla's `LecternMenu(int, Container, ContainerData)` receives the lectern's own book container (`LecternBlockEntity$1`), never a player inventory — the menu simply is not told who opened it.

The cast is a leftover from CraftBukkit, where `LecternMenu` is patched to take the player inventory as an extra constructor argument. When the mixin was first added in 662ec4d7 it still had that extra `PlayerInventory playerinventory` parameter; the cleanup in 96a3e51d dropped the parameter to match the vanilla signature and cast the lectern container instead. Later commits only renamed types (`PlayerInventory` → `Inventory`) and interfaces (`IMixinEntity` → `EntityBridge`), so the broken cast has been carried forward ever since.

## The fix

Take the player where it is actually available. `LecternBlockEntity#createMenu(int, Inventory, Player)` gets the opening player from `MenuProvider`, so a small mixin there hands it to the menu through a new `LecternMenuBridge`:

* `LecternMenuBridge` — `setPlayer(org.bukkit.entity.Player)`, mirroring the extra constructor argument CraftBukkit patches in.
* `LecternMenuMixin` — the impossible constructor injection is gone; the class implements the bridge instead.
* `LecternBlockEntityMixin` — new, injects at `createMenu` `RETURN` and passes the viewer to the returned menu.
* `bukkitfabric.mixins.json` — registers the new mixin.

`createMenu` runs before the inventory-open event and before any button click, so `getBukkitView()` and `clickMenuButton` both see a real player.

## Testing

`compileJava` passes. In game: the reading screen opens with a clean console, the page arrows work, and the "Take Book" button returns the book — that last path could not run at all before, and it now fires `PlayerTakeLecternBookEvent` with a non-null player for plugins.
