### PR TITLE
fix: stop crafters throwing NullPointerException when opened (1.21.11)

### DIFF
--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryCrafter.java
+++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryCrafter.java
@@ -1,0 +1,11 @@
+package org.bukkit.craftbukkit.inventory;
+
+import net.minecraft.world.Container;
+import org.bukkit.inventory.CrafterInventory;
+
+public class CraftInventoryCrafter extends CraftInventory implements CrafterInventory {
+
+    public CraftInventoryCrafter(Container inventory) {
+        super(inventory);
+    }
+}

--- a/src/main/java/org/cardboardpowered/mixin/world/inventory/AbstractContainerMenuMixin.java
+++ b/src/main/java/org/cardboardpowered/mixin/world/inventory/AbstractContainerMenuMixin.java
@@ -72,8 +72,10 @@ public abstract class AbstractContainerMenuMixin implements AbstractContainerMen
     public void transferTo(AbstractContainerMenu other, CraftHumanEntity player) {
         InventoryView source = this.getBukkitView(), destination = ((AbstractContainerMenuBridge)other).getBukkitView();
 
-        if ((source.getTopInventory() instanceof CustomInventoryView) || source.getBottomInventory() instanceof CustomInventoryView ||
-                destination.getTopInventory() instanceof CustomInventoryView || destination.getBottomInventory() instanceof CustomInventoryView) {
+        // Fallback views (CustomInventoryView) have no player attached, so their bottom
+        // inventory can not be resolved - skip them instead of throwing a NullPointerException.
+        if (source instanceof CustomInventoryView || destination instanceof CustomInventoryView
+                || source.getPlayer() == null || destination.getPlayer() == null) {
             return;
         }
 

--- a/src/main/java/org/cardboardpowered/mixin/world/inventory/CrafterMenuMixin.java
+++ b/src/main/java/org/cardboardpowered/mixin/world/inventory/CrafterMenuMixin.java
@@ -1,0 +1,45 @@
+package org.cardboardpowered.mixin.world.inventory;
+
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.CraftingContainer;
+import net.minecraft.world.inventory.CrafterMenu;
+import org.bukkit.craftbukkit.inventory.CraftInventoryCrafter;
+import org.bukkit.craftbukkit.inventory.view.CraftCrafterView;
+import org.bukkit.entity.HumanEntity;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import org.cardboardpowered.bridge.world.entity.EntityBridge;
+
+@Mixin(CrafterMenu.class)
+public class CrafterMenuMixin extends AbstractContainerMenuMixin {
+
+    @Shadow
+    @Final
+    private CraftingContainer container;
+
+    @Shadow
+    @Final
+    private Player player;
+
+    private CraftCrafterView bukkitEntity;
+
+    @Override
+    public CraftCrafterView getBukkitView() {
+        if (bukkitEntity != null)
+            return bukkitEntity;
+
+        bukkitEntity = new CraftCrafterView((HumanEntity) ((EntityBridge) this.player).getBukkitEntity(),
+                new CraftInventoryCrafter(this.container), (CrafterMenu) (Object) this);
+        return bukkitEntity;
+    }
+
+    @Inject(method = "stillValid", at = @At("HEAD"), cancellable = true)
+    public void stillValidCraftBukkit(Player player, CallbackInfoReturnable<Boolean> cir) {
+        if (!this.checkReachable) cir.setReturnValue(true); // CraftBukkit
+    }
+}

--- a/src/main/resources/bukkitfabric.mixins.json
+++ b/src/main/resources/bukkitfabric.mixins.json
@@ -123,6 +123,7 @@
     "world.inventory.BrewingStandMenuMixin",
     "world.inventory.ChestMenuMixin",
     "world.inventory.ContainerLevelAccessMixin",
+    "world.inventory.CrafterMenuMixin",
     "world.inventory.CraftingMenuMixin",
     "world.inventory.DispenserMenuMixin",
     "world.inventory.EnchantmentMenuMixin",


### PR DESCRIPTION
### Problem

Right-clicking a crafter kicks the player and spams the console:

```
java.lang.NullPointerException: Cannot invoke "org.bukkit.craftbukkit.entity.CraftHumanEntity.getInventory()" because "this.player" is null
	at org.bukkit.craftbukkit.inventory.CraftInventoryView.getBottomInventory(CraftInventoryView.java:42)
	at net.minecraft.world.inventory.AbstractContainerMenu.transferTo(...)
	at org.bukkit.craftbukkit.event.CraftEventFactory.callInventoryOpenEventWithTitle(CraftEventFactory.java:346)
	at net.minecraft.server.level.ServerPlayer.openMenu(...)
	at net.minecraft.world.level.block.CrafterBlock.useWithoutItem(...)
```

`CrafterMenu` has no Bukkit view of its own, so it falls back to
`AbstractContainerMenuMixin#getBukkitView()`, which builds a `CustomInventoryView`
with a `null` player. `transferTo` then asks that view for its bottom
(player) inventory while `InventoryOpenEvent` is being prepared and dies.
Result: the crafter GUI never opens and `InventoryOpenEvent` /
`InventoryClickEvent` are never delivered to plugins.

### Fix

* New `CrafterMenuMixin` returns a cached `CraftCrafterView` built from the
  menu's own `container` and `player` fields, matching what every other menu
  (dispenser, shulker box, ...) already does. It also honours `checkReachable`
  in `stillValid`, like the sibling mixins.
* New `CraftInventoryCrafter` (`CraftInventory implements CrafterInventory`)
  so `CrafterView#getTopInventory()` returns the API type it promises.
* `AbstractContainerMenuMixin#transferTo` now skips views that have no player
  instead of dereferencing null. The old guard tested
  `source.getTopInventory() instanceof CustomInventoryView` — an *inventory*
  is never a *view*, so that check could never fire and every menu lacking a
  dedicated view was one open away from the same crash.

### Testing

`gradlew compileJava` passes. Opening a crafter in-game no longer throws, the
GUI opens, and `InventoryOpenEvent` fires with a `CrafterView` whose
`isSlotDisabled` / `isPowered` / `setSlotDisabled` work.