### PR TITLE
feat(i18n): send a real permission message in the player's language (26.1)

### DIFF
--- a/src/main/java/io/papermc/paper/adventure/PaperAdventure.java
+++ b/src/main/java/io/papermc/paper/adventure/PaperAdventure.java
@@ -206,6 +206,16 @@ public final class PaperAdventure {
         return WRAPPER_AWARE_SERIALIZER.serialize(component);
     }
 
+    /**
+     * As {@link #asVanilla(Component)}, but resolves translatable components against the
+     * given locale first, so the receiver is shown their own language.
+     */
+    @Contract("null, _ -> null; !null, _ -> !null")
+    public static net.minecraft.network.chat.Component asVanilla(final @Nullable Component component, final @Nullable Locale locale) {
+        if (component == null) return null;
+        return asVanilla(translated(component, locale));
+    }
+
     public static List<net.minecraft.network.chat.Component> asVanilla(final List<? extends Component> adventures) {
         final List<net.minecraft.network.chat.Component> vanillas = new ArrayList<>(adventures.size());
         for (final Component adventure : adventures) {

--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
@@ -65,6 +65,10 @@ import io.papermc.paper.registry.RegistryAccess;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import net.kyori.adventure.translation.GlobalTranslator;
+import org.cardboardpowered.impl.CardboardTranslations;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.minecraft.ChatFormatting;
 import net.minecraft.SharedConstants;
@@ -320,6 +324,7 @@ public class CraftServer extends CardboardAbstractServer implements Server {
         INSTANCE = this;
         server = nms;
         console = nms;
+        CardboardTranslations.register();
         commandMap = new CommandMapImpl(this);
 
         // Paper start
@@ -2037,8 +2042,11 @@ public class CraftServer extends CardboardAbstractServer implements Server {
     }
 
     @Override
+    @Deprecated
     public String getPermissionMessage() {
-        return "No Permission";
+        // The legacy API has no receiver to localise for, so this is the English text.
+        return LegacyComponentSerializer.legacySection()
+                .serialize(GlobalTranslator.render(this.permissionMessage(), Locale.ENGLISH));
     }
 
     @Override
@@ -2347,8 +2355,14 @@ public class CraftServer extends CardboardAbstractServer implements Server {
 
 	@Override
 	public @NotNull Component permissionMessage() {
-		// TODO Auto-generated method stub
-		return Component.text("todo: permissionMessage");
+		// An admin-supplied message wins, and is read as legacy '&' coloured text the way
+		// the rest of bukkit.yml is. Otherwise use Cardboard's own message, which is
+		// translated into the language of whoever ends up receiving it.
+		String configured = this.configuration.getString("settings.permissions-message");
+		if (configured != null && !configured.isEmpty())
+			return LegacyComponentSerializer.legacyAmpersand().deserialize(configured);
+
+		return Component.translatable(CardboardTranslations.COMMAND_NO_PERMISSION, NamedTextColor.RED);
 	}
 
 	@Override

--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
@@ -2718,8 +2718,9 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
     // Paper start
     @Override
     public java.util.Locale locale() {
-        //return getHandle().adventure$locale; // TODO
-        return Locale.ENGLISH;
+        // The client reports its language as "uk_ua"; Adventure parses that shape directly.
+        final Locale locale = net.kyori.adventure.translation.Translator.parseLocale(this.getLocale());
+        return locale != null ? locale : Locale.ENGLISH;
     }
     // Paper end
 
@@ -2819,7 +2820,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
     public void sendMessage(net.kyori.adventure.text.Component message, net.kyori.adventure.chat.ChatType.Bound boundChatType) {
         if (getHandle().connection == null) return;
 
-        net.minecraft.network.chat.Component component = io.papermc.paper.adventure.PaperAdventure.asVanilla(message);
+        net.minecraft.network.chat.Component component = io.papermc.paper.adventure.PaperAdventure.asVanilla(message, this.locale());
         this.getHandle().sendChatMessage(new net.minecraft.network.chat.OutgoingChatMessage.Disguised(component), this.getHandle().isTextFilteringEnabled(), this.toHandle(boundChatType));
     }
 
@@ -2853,7 +2854,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
     public void sendMessage(final net.kyori.adventure.identity.Identity identity, final net.kyori.adventure.text.Component message, final net.kyori.adventure.audience.MessageType type) {
         if (getHandle().connection == null) return;
         final net.minecraft.core.Registry<net.minecraft.network.chat.ChatType> chatTypeRegistry = this.getHandle().level().registryAccess().lookupOrThrow(net.minecraft.core.registries.Registries.CHAT_TYPE);
-        this.getHandle().connection.send(new net.minecraft.network.protocol.game.ClientboundSystemChatPacket(PaperAdventure.asVanilla(message), false));
+        this.getHandle().connection.send(new net.minecraft.network.protocol.game.ClientboundSystemChatPacket(PaperAdventure.asVanilla(message, this.locale()), false));
     }
 
     @Override

--- a/src/main/java/org/cardboardpowered/impl/CardboardTranslations.java
+++ b/src/main/java/org/cardboardpowered/impl/CardboardTranslations.java
@@ -1,0 +1,107 @@
+/**
+ * CardboardPowered - Bukkit/Spigot for Fabric
+ * Copyright (C) CardboardPowered.org and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.cardboardpowered.impl;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.text.MessageFormat;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+import java.util.logging.Level;
+
+import org.cardboardpowered.CardboardMod;
+
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.translation.GlobalTranslator;
+import net.kyori.adventure.translation.TranslationStore;
+
+/**
+ * Cardboard's own user-facing messages, held as Adventure translations rather than as
+ * literal text. Anything Cardboard sends is a {@code Component.translatable(...)}, which
+ * is resolved against the locale of whoever receives it: a player's client language, or
+ * English for the console. Adding a language means dropping another properties file in
+ * {@code assets/cardboard/lang} and listing its locale here, nothing else.
+ */
+public final class CardboardTranslations {
+
+    /** Sent to a command sender who lacks the permission for the command they ran. */
+    public static final String COMMAND_NO_PERMISSION = "cardboard.command.no-permission";
+
+    private static final Key SOURCE = Key.key("cardboard", "messages");
+    private static final String BUNDLE = "assets/cardboard/lang/messages_%s.properties";
+
+    /** English is the fallback and must stay first; every other locale is optional. */
+    private static final List<Locale> BUNDLED = List.of(Locale.ENGLISH, Locale.of("uk"));
+
+    private static boolean registered;
+
+    private CardboardTranslations() {
+    }
+
+    /**
+     * Registers the bundled languages with the global translator. Safe to call more than
+     * once; only the first call does any work.
+     */
+    public static synchronized void register() {
+        if (registered) return;
+        registered = true;
+
+        TranslationStore.StringBased<MessageFormat> store = TranslationStore.messageFormat(SOURCE);
+        store.defaultLocale(Locale.ENGLISH);
+
+        for (Locale locale : BUNDLED) {
+            Map<String, MessageFormat> messages = load(locale);
+            if (!messages.isEmpty()) store.registerAll(locale, messages);
+        }
+
+        GlobalTranslator.translator().addSource(store);
+    }
+
+    private static Map<String, MessageFormat> load(Locale locale) {
+        String path = String.format(BUNDLE, locale.toLanguageTag().toLowerCase(Locale.ROOT).replace('-', '_'));
+
+        // Read the file directly instead of going through ResourceBundle, which would fall
+        // back to the host machine's locale when a language is missing and hand out the
+        // wrong translations for it.
+        try (InputStream in = CardboardTranslations.class.getClassLoader().getResourceAsStream(path)) {
+            if (in == null) {
+                CardboardMod.LOGGER.warning("No Cardboard language file for " + locale + " at " + path);
+                return Map.of();
+            }
+
+            Properties properties = new Properties();
+            properties.load(new InputStreamReader(in, StandardCharsets.UTF_8));
+
+            Map<String, MessageFormat> messages = new HashMap<>(properties.size());
+            for (String key : properties.stringPropertyNames())
+                messages.put(key, new MessageFormat(properties.getProperty(key), locale));
+
+            return messages;
+        } catch (IOException ex) {
+            CardboardMod.LOGGER.log(Level.WARNING, "Could not read the Cardboard language file for " + locale, ex);
+            return Map.of();
+        }
+    }
+
+}

--- a/src/main/resources/assets/cardboard/lang/messages_en.properties
+++ b/src/main/resources/assets/cardboard/lang/messages_en.properties
@@ -1,0 +1,2 @@
+# Cardboard messages - English (fallback language)
+cardboard.command.no-permission=I''m sorry, but you do not have permission to perform this command. Please contact the server administrators if you believe that this is in error.

--- a/src/main/resources/assets/cardboard/lang/messages_uk.properties
+++ b/src/main/resources/assets/cardboard/lang/messages_uk.properties
@@ -1,0 +1,2 @@
+# Cardboard messages - Ukrainian
+cardboard.command.no-permission=На жаль, у вас немає дозволу виконувати цю команду. Якщо ви вважаєте це помилкою, зверніться до адміністрації сервера.


### PR DESCRIPTION
### The bug

`Server#permissionMessage()` was a stub:

```java
public @NotNull Component permissionMessage() {
    // TODO Auto-generated method stub
    return Component.text("todo: permissionMessage");
}
```

Paper's `Command#testPermission` sends exactly this component to anyone who runs a command they lack the permission for, so that literal text is what players saw. The deprecated `getPermissionMessage()` returned a bare `"No Permission"`.

### The fix

Cardboard's user-facing text is now held as Adventure translations rather than literal strings. `CardboardTranslations` registers a `TranslationStore` with the global translator at startup, backed by properties files under `assets/cardboard/lang`. English is the fallback, and Ukrainian ships alongside it — adding a language is one more file plus its locale in the list, no code changes.

The files are read directly rather than through `ResourceBundle`, which falls back to the *host machine's* locale when a language is missing: on a server running with a Ukrainian system locale, that would hand Ukrainian to a German player.

An admin who sets `settings.permissions-message` in `bukkit.yml` still wins, read as legacy `&`-coloured text like the rest of that file. `getPermissionMessage()` returns the English rendering of the same message, since the legacy API has no receiver to localise for.

### Delivering it in the right language

Two gaps had to be closed for any of this to reach the player:

- `CraftPlayer#locale()` always answered `Locale.ENGLISH` behind a TODO, even though the client's language was already on the handle and `getLocale()` returned it. It now parses that through `Translator#parseLocale`.
- Components were converted for sending with no locale at all, so no translatable component was ever resolved per receiver — `PaperAdventure.localizedCodec` existed but nothing called it. Added a locale-aware `PaperAdventure#asVanilla(Component, Locale)` over the existing `translated(...)`, and wired the chat send paths to it. Plugins sending translatable components get the same benefit.

### Testing

`gradlew build` passes. Rendering was exercised on a live JVM, not just compiled: `uk_ua` and `uk` resolve to the Ukrainian text, `en_us`, `de_de` and `pt_br` fall back to English, and the `MessageFormat` quoting renders `I'm` correctly.

Two known limits, both stated rather than worked around: the console and `sendMessage(String)` always get English, since neither has a receiver locale; and the `<permission>` placeholder Paper substitutes into custom messages does not apply to a translatable component, as it matches literal text.
