### PR TITLE
fix: stop /say and mod command output being swallowed (1.21.11)

### DIFF
--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
@@ -1067,8 +1067,13 @@ public class CraftServer implements Server {
 	@Override
 	public boolean dispatchCommand(CommandSender sender, String commandLine) throws CommandException {
 		if(sender instanceof Entity) {
-			ServerLevel world = (ServerLevel) ((CraftEntity) sender).getHandle().level();
-			CommandSourceStack source = ((CraftEntity) sender).getHandle().createCommandSourceStackForNameResolution(world);
+			net.minecraft.world.entity.Entity handle = ((CraftEntity) sender).getHandle();
+			ServerLevel world = (ServerLevel) handle.level();
+			// A name-resolution source discards all output and carries no permissions, so commands
+			// run through it silently do nothing. Players get their real source stack instead.
+			CommandSourceStack source = (handle instanceof ServerPlayer serverPlayer)
+					? serverPlayer.createCommandSourceStack()
+					: handle.createCommandSourceStackForNameResolution(world);
 
 			try {
 				String theCommand;

--- a/src/main/java/org/cardboardpowered/mixin/server/players/PlayerListMixin_ChatEvent.java
+++ b/src/main/java/org/cardboardpowered/mixin/server/players/PlayerListMixin_ChatEvent.java
@@ -64,24 +64,26 @@ public class PlayerListMixin_ChatEvent {
      */
     @Overwrite
     public void broadcastChatMessage(PlayerChatMessage message, Predicate<ServerPlayer> shouldSendFiltered, ServerPlayer sender/*, MessageSourceProfile sourceProfile*/, ChatType.Bound params) {
-        CardboardMod.LOGGER.info("BROADCAST DEBUG: " + message.decoratedContent().getString());
-        
     	boolean bl = this.verifyChatTrusted(message);
-        this.server.logChatMessage(message.decoratedContent(), params, null);
-        OutgoingChatMessage sentMessage = OutgoingChatMessage.create(message);
-        boolean bl2 = message.isFullyFiltered();
-        boolean bl3 = false;
-        /*for (ServerPlayerEntity serverPlayerEntity : this.players) {
-            boolean bl4 = shouldSendFiltered.test(serverPlayerEntity);
-            serverPlayerEntity.sendChatMessage(sentMessage, bl4, params);
-            if (sender == serverPlayerEntity) continue;
-            bl3 |= bl2 && bl4;
+        this.server.logChatMessage(message.decoratedContent(), params, bl ? null : "Not Secure");
+
+        // Only real player chat goes through the Bukkit chat events. /say, /me, /msg, command
+        // blocks and mod broadcasts have no chat sender and must keep vanilla delivery, otherwise
+        // they either NPE below or get reformatted with the chat format.
+        if (sender == null || !params.chatType().is(ChatType.CHAT)) {
+            OutgoingChatMessage vanillaMessage = OutgoingChatMessage.create(message);
+            boolean fullyFiltered = message.isFullyFiltered();
+            boolean notifySender = false;
+            for (ServerPlayer recipient : this.players) {
+                boolean filtered = shouldSendFiltered.test(recipient);
+                recipient.sendChatMessage(vanillaMessage, filtered, params);
+                if (sender == recipient) continue;
+                notifySender |= fullyFiltered && filtered;
+            }
+            if (notifySender && sender != null) sender.sendSystemMessage(PlayerList.CHAT_FILTERED_FULL);
+            return;
         }
-        if (bl3 && sender != null) {
-            sender.sendMessage(PlayerManager.FILTERED_FULL_TEXT);
-        }*/
-        
-        
+
         String s = message.decoratedContent().getString();
 		boolean async = false; // TODO: allow async
 
@@ -89,7 +91,6 @@ public class PlayerListMixin_ChatEvent {
         AsyncPlayerChatEvent event = new AsyncPlayerChatEvent(async, player, s, new LazyPlayerSet(CraftServer.server));
         Bukkit.getServer().getPluginManager().callEvent(event);
 
-        CardboardMod.LOGGER.info("Reg: " + PlayerChatEvent.getHandlerList().getRegisteredListeners().length);
         if (PlayerChatEvent.getHandlerList().getRegisteredListeners().length != 0) {
             // Evil plugins still listening to deprecated event
             final PlayerChatEvent queueEvent = new PlayerChatEvent(player, event.getMessage(), event.getFormat(), event.getRecipients());


### PR DESCRIPTION
### The problem

Two unrelated paths both end up looking like "the server has muted itself".

**`/say` from the console throws.** `PlayerListMixin_ChatEvent` overwrites `PlayerList.broadcastChatMessage` so it can fire `AsyncPlayerChatEvent`, but it did that for *every* chat type and called `getPlayer_0(sender)` unconditionally. `/say`, `/me`, `/msg`, command blocks and mod broadcasts have no chat sender, so `sender` is `null` and the overwrite NPEs — after `logChatMessage` has already run, which is why the console shows the message and then `An unexpected error occurred trying to execute that command`:

```
[15:38:01] [Server thread/INFO]: [Server] Hello
[15:38:01] [Server thread/INFO]: An unexpected error occurred trying to execute that command
```

No player ever receives it. The vanilla delivery loop was commented out entirely, so even the chat types that survived reached nobody.

**Player commands run with no output and no permissions.** `CraftServer.dispatchCommand` built its `CommandSourceStack` with `Entity#createCommandSourceStackForNameResolution`, which vanilla constructs with `CommandSource.NULL` and `PermissionSet.NO_PERMISSIONS` — it exists for resolving selector names, not for running commands. With `registry-command-fix` enabled (the default) every command a player types goes through `Bukkit.dispatchCommand` and therefore through this source, so mod and vanilla commands executed with all their feedback discarded. On a server with e.g. [audio-player](https://github.com/henkelmax/audio-player), `/audioplayer url ...` and `/audioplayer apply ...` are logged as issued and then reply with nothing at all.

### The fix

- Restrict the Bukkit chat events to real player chat (`sender != null` and `ChatType.CHAT`); every other chat type gets the vanilla `sendChatMessage` delivery loop back, including the `CHAT_FILTERED_FULL` notice.
- Pass the `"Not Secure"` marker to `logChatMessage` instead of dropping the already-computed `verifyChatTrusted` result.
- Remove two leftover debug lines (`BROADCAST DEBUG:` and `Reg:`) that printed on every chat message.
- Use `ServerPlayer#createCommandSourceStack()` for players in `dispatchCommand`, falling back to the name-resolution stack for other entities.

### Testing

`./gradlew compileJava` passes on both `ver/1.21.11` and `ver/26.1`. In-game testing still to do: `/say` from console reaching all players, `/me` and `/msg`, player chat still going through `AsyncPlayerChatEvent`, and mod command feedback such as audio-player's.
