### PR TITLE
feat(plugins): implement the Paper plugin lifecycle and Brigadier command API (1.21.11)

### DIFF
--- a/src/main/java/io/papermc/paper/plugin/lifecycle/event/PaperLifecycleEventManager.java
+++ b/src/main/java/io/papermc/paper/plugin/lifecycle/event/PaperLifecycleEventManager.java
@@ -1,8 +1,8 @@
 package io.papermc.paper.plugin.lifecycle.event;
 
 import com.google.common.base.Preconditions;
-//import io.papermc.paper.plugin.lifecycle.event.handler.configuration.AbstractLifecycleEventHandlerConfiguration;
 import io.papermc.paper.plugin.lifecycle.event.handler.configuration.LifecycleEventHandlerConfiguration;
+import io.papermc.paper.plugin.lifecycle.event.types.CardboardHandlerConfiguration;
 import java.util.function.BooleanSupplier;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.framework.qual.DefaultQualifier;
@@ -21,6 +21,8 @@ public final class PaperLifecycleEventManager<O extends LifecycleEventOwner> imp
     @Override
     public void registerEventHandler(final LifecycleEventHandlerConfiguration<? super O> handlerConfiguration) {
         Preconditions.checkState(this.registrationCheck.getAsBoolean(), "Cannot register lifecycle event handlers");
-        //((AbstractLifecycleEventHandlerConfiguration<? super O, ?>) handlerConfiguration).registerFrom(this.owner);
+        Preconditions.checkArgument(handlerConfiguration instanceof CardboardHandlerConfiguration,
+                "Unknown lifecycle event handler configuration: %s", handlerConfiguration.getClass().getName());
+        ((CardboardHandlerConfiguration) handlerConfiguration).registerTo(this.owner);
     }
 }

--- a/src/main/java/io/papermc/paper/plugin/lifecycle/event/types/CardboardHandlerConfiguration.java
+++ b/src/main/java/io/papermc/paper/plugin/lifecycle/event/types/CardboardHandlerConfiguration.java
@@ -1,0 +1,12 @@
+package io.papermc.paper.plugin.lifecycle.event.types;
+
+import io.papermc.paper.plugin.lifecycle.event.LifecycleEventOwner;
+
+/**
+ * Implemented by every handler configuration Cardboard hands back to plugins, so that the
+ * lifecycle event manager can attach a finished configuration to its owner.
+ */
+public interface CardboardHandlerConfiguration {
+
+    void registerTo(LifecycleEventOwner owner);
+}

--- a/src/main/java/io/papermc/paper/plugin/lifecycle/event/types/CardboardLifecycleEventRunner.java
+++ b/src/main/java/io/papermc/paper/plugin/lifecycle/event/types/CardboardLifecycleEventRunner.java
@@ -1,0 +1,51 @@
+package io.papermc.paper.plugin.lifecycle.event.types;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import io.papermc.paper.plugin.lifecycle.event.LifecycleEvent;
+import io.papermc.paper.plugin.lifecycle.event.LifecycleEventOwner;
+
+/**
+ * Entry point the rest of Cardboard uses to drive the plugin lifecycle events.
+ */
+public final class CardboardLifecycleEventRunner {
+
+    private static final List<CardboardLifecycleEventType<?, ?, ?>> EVENT_TYPES = new CopyOnWriteArrayList<>();
+
+    private static LifecycleEventOwner currentOwner;
+
+    private CardboardLifecycleEventRunner() {
+    }
+
+    static void track(CardboardLifecycleEventType<?, ?, ?> eventType) {
+        EVENT_TYPES.add(eventType);
+    }
+
+    /**
+     * The plugin whose handler is running right now, or null outside of a handler. Registrars use
+     * this to attribute what a handler registers back to the plugin that registered it.
+     */
+    public static LifecycleEventOwner currentOwner() {
+        return currentOwner;
+    }
+
+    static void setCurrentOwner(LifecycleEventOwner owner) {
+        currentOwner = owner;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <E extends LifecycleEvent> void fire(LifecycleEventType<?, ? extends E, ?> eventType, E event) {
+        if (eventType instanceof CardboardLifecycleEventType<?, ?, ?> cardboardType)
+            ((CardboardLifecycleEventType<?, E, ?>) cardboardType).fire(event);
+    }
+
+    /**
+     * Forgets every handler the given owner registered, for every lifecycle event. Called when a
+     * plugin is disabled so a reload does not run its handlers twice.
+     */
+    public static void removeOwner(LifecycleEventOwner owner) {
+        for (CardboardLifecycleEventType<?, ?, ?> eventType : EVENT_TYPES)
+            eventType.removeOwner(owner);
+    }
+}

--- a/src/main/java/io/papermc/paper/plugin/lifecycle/event/types/CardboardLifecycleEventType.java
+++ b/src/main/java/io/papermc/paper/plugin/lifecycle/event/types/CardboardLifecycleEventType.java
@@ -1,0 +1,91 @@
+package io.papermc.paper.plugin.lifecycle.event.types;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.logging.Level;
+
+import io.papermc.paper.plugin.lifecycle.event.LifecycleEvent;
+import io.papermc.paper.plugin.lifecycle.event.LifecycleEventOwner;
+import io.papermc.paper.plugin.lifecycle.event.handler.LifecycleEventHandler;
+import io.papermc.paper.plugin.lifecycle.event.handler.configuration.LifecycleEventHandlerConfiguration;
+import org.bukkit.Bukkit;
+
+/**
+ * Holds the handlers plugins registered for one lifecycle event, and runs them when the
+ * server fires that event.
+ */
+public abstract class CardboardLifecycleEventType<O extends LifecycleEventOwner, E extends LifecycleEvent, C extends LifecycleEventHandlerConfiguration<O>>
+        implements LifecycleEventType<O, E, C> {
+
+    private record RegisteredHandler<E extends LifecycleEvent>(LifecycleEventOwner owner,
+                                                               LifecycleEventHandler<? super E> handler,
+                                                               int priority, boolean monitor) {
+    }
+
+    // Monitors run after everyone else, and within each group the lower priority runs first.
+    private static final Comparator<RegisteredHandler<?>> ORDER =
+            Comparator.<RegisteredHandler<?>>comparingInt(h -> h.monitor() ? 1 : 0)
+                    .thenComparingInt(RegisteredHandler::priority);
+
+    private final String name;
+    private final List<RegisteredHandler<E>> handlers = new ArrayList<>();
+
+    protected CardboardLifecycleEventType(String name) {
+        this.name = name;
+        CardboardLifecycleEventRunner.track(this);
+    }
+
+    @Override
+    public String name() {
+        return this.name;
+    }
+
+    void register(LifecycleEventOwner owner, LifecycleEventHandler<? super E> handler, int priority, boolean monitor) {
+        synchronized (this.handlers) {
+            this.handlers.add(new RegisteredHandler<>(owner, handler, priority, monitor));
+            this.handlers.sort(ORDER);
+        }
+    }
+
+    /**
+     * Drops everything an owner registered, so that disabling or reloading a plugin does not
+     * leave its handlers behind to run a second time.
+     */
+    public void removeOwner(LifecycleEventOwner owner) {
+        synchronized (this.handlers) {
+            this.handlers.removeIf(h -> h.owner() == owner);
+        }
+    }
+
+    /**
+     * Runs every registered handler. A handler that throws is logged against its own owner and
+     * does not stop the remaining handlers.
+     */
+    public void fire(E event) {
+        List<RegisteredHandler<E>> snapshot;
+        synchronized (this.handlers) {
+            snapshot = List.copyOf(this.handlers);
+        }
+
+        for (RegisteredHandler<E> registered : snapshot) {
+            CardboardLifecycleEventRunner.setCurrentOwner(registered.owner());
+            try {
+                registered.handler().run(event);
+            } catch (Throwable throwable) {
+                Bukkit.getLogger().log(Level.SEVERE, "Plugin " + ownerName(registered.owner())
+                        + " failed handling the '" + this.name + "' lifecycle event", throwable);
+            } finally {
+                CardboardLifecycleEventRunner.setCurrentOwner(null);
+            }
+        }
+    }
+
+    private static String ownerName(LifecycleEventOwner owner) {
+        try {
+            return owner.getPluginMeta().getDisplayName();
+        } catch (Throwable ignored) {
+            return String.valueOf(owner);
+        }
+    }
+}

--- a/src/main/java/io/papermc/paper/plugin/lifecycle/event/types/CardboardLifecycleEventTypeProvider.java
+++ b/src/main/java/io/papermc/paper/plugin/lifecycle/event/types/CardboardLifecycleEventTypeProvider.java
@@ -1,0 +1,48 @@
+package io.papermc.paper.plugin.lifecycle.event.types;
+
+import io.papermc.paper.plugin.bootstrap.BootstrapContext;
+import io.papermc.paper.plugin.lifecycle.event.LifecycleEvent;
+import io.papermc.paper.plugin.lifecycle.event.LifecycleEventOwner;
+import io.papermc.paper.plugin.lifecycle.event.registrar.ReloadableRegistrarEvent;
+import io.papermc.paper.registry.RegistryKey;
+import io.papermc.paper.tag.PostFlattenTagRegistrar;
+import io.papermc.paper.tag.PreFlattenTagRegistrar;
+
+/**
+ * Backs the lifecycle event API. Found through {@code META-INF/services}; without it every
+ * reference to {@link LifecycleEvents} fails to initialise.
+ */
+public class CardboardLifecycleEventTypeProvider implements LifecycleEventTypeProvider {
+
+    @Override
+    public <O extends LifecycleEventOwner, E extends LifecycleEvent> LifecycleEventType.Monitorable<O, E> monitor(String name, Class<? extends O> ownerType) {
+        return new CardboardMonitorableEventType<>(name);
+    }
+
+    @Override
+    public <O extends LifecycleEventOwner, E extends LifecycleEvent> LifecycleEventType.Prioritizable<O, E> prioritized(String name, Class<? extends O> ownerType) {
+        return new CardboardPrioritizableEventType<>(name);
+    }
+
+    @Override
+    public TagEventTypeProvider tagProvider() {
+        return new CardboardTagEventTypeProvider();
+    }
+
+    /**
+     * Tag rewriting happens during plugin bootstrap, which Cardboard does not run. The event types
+     * are still handed out so that touching them does not crash; they simply never fire.
+     */
+    private static final class CardboardTagEventTypeProvider implements TagEventTypeProvider {
+
+        @Override
+        public <T> LifecycleEventType.Prioritizable<BootstrapContext, ReloadableRegistrarEvent<PreFlattenTagRegistrar<T>>> preFlatten(RegistryKey<T> registryKey) {
+            return new CardboardPrioritizableEventType<>("tags/pre_flatten/" + registryKey);
+        }
+
+        @Override
+        public <T> LifecycleEventType.Prioritizable<BootstrapContext, ReloadableRegistrarEvent<PostFlattenTagRegistrar<T>>> postFlatten(RegistryKey<T> registryKey) {
+            return new CardboardPrioritizableEventType<>("tags/post_flatten/" + registryKey);
+        }
+    }
+}

--- a/src/main/java/io/papermc/paper/plugin/lifecycle/event/types/CardboardMonitorHandlerConfiguration.java
+++ b/src/main/java/io/papermc/paper/plugin/lifecycle/event/types/CardboardMonitorHandlerConfiguration.java
@@ -1,0 +1,30 @@
+package io.papermc.paper.plugin.lifecycle.event.types;
+
+import io.papermc.paper.plugin.lifecycle.event.LifecycleEvent;
+import io.papermc.paper.plugin.lifecycle.event.LifecycleEventOwner;
+import io.papermc.paper.plugin.lifecycle.event.handler.LifecycleEventHandler;
+import io.papermc.paper.plugin.lifecycle.event.handler.configuration.MonitorLifecycleEventHandlerConfiguration;
+
+public final class CardboardMonitorHandlerConfiguration<O extends LifecycleEventOwner, E extends LifecycleEvent>
+        implements MonitorLifecycleEventHandlerConfiguration<O>, CardboardHandlerConfiguration {
+
+    private final CardboardLifecycleEventType<O, E, ?> eventType;
+    private final LifecycleEventHandler<? super E> handler;
+    private boolean monitor;
+
+    CardboardMonitorHandlerConfiguration(CardboardLifecycleEventType<O, E, ?> eventType, LifecycleEventHandler<? super E> handler) {
+        this.eventType = eventType;
+        this.handler = handler;
+    }
+
+    @Override
+    public MonitorLifecycleEventHandlerConfiguration<O> monitor() {
+        this.monitor = true;
+        return this;
+    }
+
+    @Override
+    public void registerTo(LifecycleEventOwner owner) {
+        this.eventType.register(owner, this.handler, 0, this.monitor);
+    }
+}

--- a/src/main/java/io/papermc/paper/plugin/lifecycle/event/types/CardboardMonitorableEventType.java
+++ b/src/main/java/io/papermc/paper/plugin/lifecycle/event/types/CardboardMonitorableEventType.java
@@ -1,0 +1,20 @@
+package io.papermc.paper.plugin.lifecycle.event.types;
+
+import io.papermc.paper.plugin.lifecycle.event.LifecycleEvent;
+import io.papermc.paper.plugin.lifecycle.event.LifecycleEventOwner;
+import io.papermc.paper.plugin.lifecycle.event.handler.LifecycleEventHandler;
+import io.papermc.paper.plugin.lifecycle.event.handler.configuration.MonitorLifecycleEventHandlerConfiguration;
+
+public final class CardboardMonitorableEventType<O extends LifecycleEventOwner, E extends LifecycleEvent>
+        extends CardboardLifecycleEventType<O, E, MonitorLifecycleEventHandlerConfiguration<O>>
+        implements LifecycleEventType.Monitorable<O, E> {
+
+    CardboardMonitorableEventType(String name) {
+        super(name);
+    }
+
+    @Override
+    public MonitorLifecycleEventHandlerConfiguration<O> newHandler(LifecycleEventHandler<? super E> handler) {
+        return new CardboardMonitorHandlerConfiguration<>(this, handler);
+    }
+}

--- a/src/main/java/io/papermc/paper/plugin/lifecycle/event/types/CardboardPrioritizableEventType.java
+++ b/src/main/java/io/papermc/paper/plugin/lifecycle/event/types/CardboardPrioritizableEventType.java
@@ -1,0 +1,20 @@
+package io.papermc.paper.plugin.lifecycle.event.types;
+
+import io.papermc.paper.plugin.lifecycle.event.LifecycleEvent;
+import io.papermc.paper.plugin.lifecycle.event.LifecycleEventOwner;
+import io.papermc.paper.plugin.lifecycle.event.handler.LifecycleEventHandler;
+import io.papermc.paper.plugin.lifecycle.event.handler.configuration.PrioritizedLifecycleEventHandlerConfiguration;
+
+public final class CardboardPrioritizableEventType<O extends LifecycleEventOwner, E extends LifecycleEvent>
+        extends CardboardLifecycleEventType<O, E, PrioritizedLifecycleEventHandlerConfiguration<O>>
+        implements LifecycleEventType.Prioritizable<O, E> {
+
+    CardboardPrioritizableEventType(String name) {
+        super(name);
+    }
+
+    @Override
+    public PrioritizedLifecycleEventHandlerConfiguration<O> newHandler(LifecycleEventHandler<? super E> handler) {
+        return new CardboardPrioritizedHandlerConfiguration<>(this, handler);
+    }
+}

--- a/src/main/java/io/papermc/paper/plugin/lifecycle/event/types/CardboardPrioritizedHandlerConfiguration.java
+++ b/src/main/java/io/papermc/paper/plugin/lifecycle/event/types/CardboardPrioritizedHandlerConfiguration.java
@@ -1,0 +1,38 @@
+package io.papermc.paper.plugin.lifecycle.event.types;
+
+import io.papermc.paper.plugin.lifecycle.event.LifecycleEvent;
+import io.papermc.paper.plugin.lifecycle.event.LifecycleEventOwner;
+import io.papermc.paper.plugin.lifecycle.event.handler.LifecycleEventHandler;
+import io.papermc.paper.plugin.lifecycle.event.handler.configuration.PrioritizedLifecycleEventHandlerConfiguration;
+
+public final class CardboardPrioritizedHandlerConfiguration<O extends LifecycleEventOwner, E extends LifecycleEvent>
+        implements PrioritizedLifecycleEventHandlerConfiguration<O>, CardboardHandlerConfiguration {
+
+    private final CardboardLifecycleEventType<O, E, ?> eventType;
+    private final LifecycleEventHandler<? super E> handler;
+    private int priority;
+    private boolean monitor;
+
+    CardboardPrioritizedHandlerConfiguration(CardboardLifecycleEventType<O, E, ?> eventType, LifecycleEventHandler<? super E> handler) {
+        this.eventType = eventType;
+        this.handler = handler;
+    }
+
+    @Override
+    public PrioritizedLifecycleEventHandlerConfiguration<O> priority(int priority) {
+        this.priority = priority;
+        this.monitor = false;
+        return this;
+    }
+
+    @Override
+    public PrioritizedLifecycleEventHandlerConfiguration<O> monitor() {
+        this.monitor = true;
+        return this;
+    }
+
+    @Override
+    public void registerTo(LifecycleEventOwner owner) {
+        this.eventType.register(owner, this.handler, this.priority, this.monitor);
+    }
+}

--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
@@ -514,6 +514,7 @@ public class CraftServer implements Server {
         if (type == PluginLoadOrder.POSTWORLD) {
             commandMap.setFallbackCommands();
             setVanillaCommands();
+            registerPluginBrigadierCommands();
             commandMap.registerServerAliases();
             DefaultPermissions.registerCorePermissions();
             CommandPermissions.registerCorePermissions();
@@ -536,6 +537,25 @@ public class CraftServer implements Server {
         }
     }
 
+
+    private boolean brigadierCommandsRegistered = false;
+
+    /**
+     * Lets plugins register Brigadier commands through the Paper lifecycle API. Runs once the
+     * vanilla commands are in the command map but before it is synced, so the commands plugins add
+     * here end up in the rebuilt dispatcher along with everything else.
+     */
+    private void registerPluginBrigadierCommands() {
+        io.papermc.paper.plugin.lifecycle.event.registrar.ReloadableRegistrarEvent.Cause cause = this.brigadierCommandsRegistered
+                ? io.papermc.paper.plugin.lifecycle.event.registrar.ReloadableRegistrarEvent.Cause.RELOAD
+                : io.papermc.paper.plugin.lifecycle.event.registrar.ReloadableRegistrarEvent.Cause.INITIAL;
+        this.brigadierCommandsRegistered = true;
+
+        io.papermc.paper.plugin.lifecycle.event.types.CardboardLifecycleEventRunner.fire(
+                io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents.COMMANDS,
+                new org.cardboardpowered.impl.command.CardboardCommandsEvent(
+                        new org.cardboardpowered.impl.command.CardboardCommands(this.vanillaCommandManager), cause));
+    }
 
     @SuppressWarnings("unchecked")
     private void syncCommands() {

--- a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
@@ -59,6 +59,18 @@ public abstract class JavaPlugin extends PluginBase {
     	return this.description;
     }
 
+    private io.papermc.paper.plugin.lifecycle.event.LifecycleEventManager<org.bukkit.plugin.Plugin> lifecycleEventManager;
+    private boolean allowsLifecycleRegistration = false;
+
+    @Override
+    public final io.papermc.paper.plugin.lifecycle.event.LifecycleEventManager<org.bukkit.plugin.Plugin> getLifecycleManager() {
+        if (this.lifecycleEventManager == null)
+            this.lifecycleEventManager = new io.papermc.paper.plugin.lifecycle.event.PaperLifecycleEventManager<>(
+                    this, () -> !this.isEnabled || this.allowsLifecycleRegistration);
+
+        return this.lifecycleEventManager;
+    }
+
     protected JavaPlugin(final JavaPluginLoader loader, final PluginDescriptionFile description, final File dataFolder, final File file) {
         final ClassLoader classLoader = this.getClass().getClassLoader();
         if (classLoader instanceof PluginClassLoader)
@@ -260,8 +272,18 @@ public abstract class JavaPlugin extends PluginBase {
             isEnabled = enabled;
 
             if (isEnabled) {
-                onEnable();
-            } else onDisable();
+                // Lifecycle handlers may only be registered while loading or enabling, matching Paper.
+                this.allowsLifecycleRegistration = true;
+                try {
+                    onEnable();
+                } finally {
+                    this.allowsLifecycleRegistration = false;
+                }
+            } else {
+                // Drop this plugin's lifecycle handlers so a reload does not run them twice.
+                io.papermc.paper.plugin.lifecycle.event.types.CardboardLifecycleEventRunner.removeOwner(this);
+                onDisable();
+            }
         }
     }
 

--- a/src/main/java/org/cardboardpowered/bridge/commands/CommandSourceBridge.java
+++ b/src/main/java/org/cardboardpowered/bridge/commands/CommandSourceBridge.java
@@ -24,7 +24,11 @@ public interface CommandSourceBridge {
     	}
     	
     	CommandSource output = source.source;
-    	
+
+    	// The console has no entity behind it, so it never reached the branches above.
+    	if (output instanceof net.minecraft.server.MinecraftServer)
+    		return org.bukkit.craftbukkit.CraftServer.INSTANCE.getConsoleSender();
+
     	// Memic Default Error
     	String msg1 = " does not define or inherit an implementation of the resolved method 'org.bukkit.command.CommandSender";
     	String msg2 = " getBukkitSender(net.minecraft.class_2168/ServerCommandSource)' of interface IMixinCommandOutput.";

--- a/src/main/java/org/cardboardpowered/impl/command/CardboardCommands.java
+++ b/src/main/java/org/cardboardpowered/impl/command/CardboardCommands.java
@@ -1,0 +1,175 @@
+package org.cardboardpowered.impl.command;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.suggestion.Suggestions;
+import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+import com.mojang.brigadier.tree.LiteralCommandNode;
+
+import io.papermc.paper.command.brigadier.BasicCommand;
+import io.papermc.paper.command.brigadier.CommandRegistrationFlag;
+import io.papermc.paper.command.brigadier.CommandSourceStack;
+import io.papermc.paper.command.brigadier.Commands;
+import io.papermc.paper.plugin.configuration.PluginMeta;
+import io.papermc.paper.plugin.lifecycle.event.LifecycleEventOwner;
+import io.papermc.paper.plugin.lifecycle.event.types.CardboardLifecycleEventRunner;
+
+import org.bukkit.craftbukkit.CraftServer;
+
+/**
+ * Cardboard's {@link Commands} registrar.
+ *
+ * <p>Plugins build their nodes against the Paper {@link CommandSourceStack}, which the vanilla
+ * source stack implements, so a node can be handed straight to the vanilla dispatcher. Every
+ * command is also registered into the Bukkit command map, which is what gives it a namespaced
+ * alias, help entry and tab completion, and what lets {@code CraftServer.syncCommands()} graft it
+ * back into the dispatcher it rebuilds afterwards.
+ */
+public final class CardboardCommands implements Commands {
+
+    private final net.minecraft.commands.Commands vanilla;
+
+    public CardboardCommands(net.minecraft.commands.Commands vanilla) {
+        this.vanilla = vanilla;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public CommandDispatcher<CommandSourceStack> getDispatcher() {
+        return (CommandDispatcher<CommandSourceStack>) (CommandDispatcher<?>) this.vanilla.getDispatcher();
+    }
+
+    @Override
+    public Set<String> register(LiteralCommandNode<CommandSourceStack> node, String description, Collection<String> aliases) {
+        return this.register(callingPlugin(), node, description, aliases);
+    }
+
+    @Override
+    public Set<String> register(PluginMeta meta, LiteralCommandNode<CommandSourceStack> node, String description, Collection<String> aliases) {
+        return this.registerWithFlags(meta, node, description, aliases, Set.of());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Set<String> registerWithFlags(PluginMeta meta, LiteralCommandNode<CommandSourceStack> node, String description,
+                                         Collection<String> aliases, Set<CommandRegistrationFlag> flags) {
+        LiteralCommandNode<net.minecraft.commands.CommandSourceStack> vanillaNode =
+                (LiteralCommandNode<net.minecraft.commands.CommandSourceStack>) (LiteralCommandNode<?>) node;
+
+        List<String> aliasList = (aliases == null) ? List.of() : List.copyOf(aliases);
+        String namespace = meta.getName().toLowerCase(Locale.ROOT);
+
+        // Into the live dispatcher first, so the command works before the command map is next synced.
+        this.vanilla.getDispatcher().getRoot().addChild(vanillaNode);
+        for (String alias : aliasList)
+            this.vanilla.getDispatcher().getRoot().addChild(cloneAs(alias, vanillaNode));
+
+        MinecraftCommandWrapper wrapper = new MinecraftCommandWrapper(this.vanilla, vanillaNode);
+        // The node's own requires() already gates the command; a "minecraft.command.*" permission
+        // node would only lock plugin commands away from everyone.
+        wrapper.setPermission(null);
+        if (description != null && !description.isEmpty()) wrapper.setDescription(description);
+        if (!aliasList.isEmpty()) wrapper.setAliases(aliasList);
+
+        String label = vanillaNode.getLiteral();
+        CraftServer.INSTANCE.getCommandMap().register(label, namespace, wrapper);
+
+        Set<String> registered = new LinkedHashSet<>();
+        registered.add(label);
+        registered.add(namespace + ":" + label);
+        for (String alias : aliasList) {
+            registered.add(alias);
+            registered.add(namespace + ":" + alias);
+        }
+        return registered;
+    }
+
+    @Override
+    public Set<String> register(String label, String description, Collection<String> aliases, BasicCommand basicCommand) {
+        return this.register(callingPlugin(), label, description, aliases, basicCommand);
+    }
+
+    @Override
+    public Set<String> register(PluginMeta meta, String label, String description, Collection<String> aliases, BasicCommand basicCommand) {
+        return this.register(meta, toNode(label, basicCommand), description, aliases);
+    }
+
+    private static LiteralCommandNode<CommandSourceStack> toNode(String label, BasicCommand basicCommand) {
+        LiteralArgumentBuilder<CommandSourceStack> builder = Commands.literal(label)
+                .requires(source -> basicCommand.canUse(source.getSender()))
+                .executes(context -> {
+                    basicCommand.execute(context.getSource(), new String[0]);
+                    return com.mojang.brigadier.Command.SINGLE_SUCCESS;
+                });
+
+        builder.then(Commands.argument("arguments", StringArgumentType.greedyString())
+                .suggests((context, suggestions) -> suggest(basicCommand, context, suggestions))
+                .executes(context -> {
+                    basicCommand.execute(context.getSource(), splitArguments(StringArgumentType.getString(context, "arguments")));
+                    return com.mojang.brigadier.Command.SINGLE_SUCCESS;
+                }));
+
+        return builder.build();
+    }
+
+    private static CompletableFuture<Suggestions> suggest(BasicCommand basicCommand, CommandContext<CommandSourceStack> context,
+                                                          SuggestionsBuilder suggestions) {
+        String remaining = suggestions.getRemaining();
+        // Brigadier hands us the whole greedy argument, but BasicCommand suggests for the word
+        // being typed, so only the trailing word is what the suggestions replace.
+        String[] arguments = splitArguments(remaining);
+        if (remaining.isEmpty() || remaining.endsWith(" ")) {
+            String[] withEmpty = new String[arguments.length + 1];
+            System.arraycopy(arguments, 0, withEmpty, 0, arguments.length);
+            withEmpty[arguments.length] = "";
+            arguments = withEmpty;
+        }
+
+        int lastSpace = remaining.lastIndexOf(' ');
+        SuggestionsBuilder offset = suggestions.createOffset(suggestions.getStart() + lastSpace + 1);
+        for (String suggestion : basicCommand.suggest(context.getSource(), arguments))
+            offset.suggest(suggestion);
+
+        return offset.buildFuture();
+    }
+
+    private static String[] splitArguments(String arguments) {
+        if (arguments.isEmpty()) return new String[0];
+
+        List<String> split = new ArrayList<>();
+        for (String part : arguments.split(" "))
+            if (!part.isEmpty()) split.add(part);
+
+        return split.toArray(new String[0]);
+    }
+
+    private static LiteralCommandNode<net.minecraft.commands.CommandSourceStack> cloneAs(String label,
+            LiteralCommandNode<net.minecraft.commands.CommandSourceStack> node) {
+        LiteralCommandNode<net.minecraft.commands.CommandSourceStack> clone = new LiteralCommandNode<>(
+                label, node.getCommand(), node.getRequirement(), node.getRedirect(), node.getRedirectModifier(), node.isFork());
+
+        for (com.mojang.brigadier.tree.CommandNode<net.minecraft.commands.CommandSourceStack> child : node.getChildren())
+            clone.addChild(child);
+
+        return clone;
+    }
+
+    private static PluginMeta callingPlugin() {
+        LifecycleEventOwner owner = CardboardLifecycleEventRunner.currentOwner();
+        if (owner == null)
+            throw new IllegalStateException("Commands can only be registered from inside a LifecycleEvents.COMMANDS handler,"
+                    + " or by passing the owning plugin's PluginMeta explicitly");
+
+        return owner.getPluginMeta();
+    }
+}

--- a/src/main/java/org/cardboardpowered/impl/command/CardboardCommandsEvent.java
+++ b/src/main/java/org/cardboardpowered/impl/command/CardboardCommandsEvent.java
@@ -1,0 +1,11 @@
+package org.cardboardpowered.impl.command;
+
+import io.papermc.paper.command.brigadier.Commands;
+import io.papermc.paper.plugin.lifecycle.event.registrar.ReloadableRegistrarEvent;
+
+/**
+ * The event handed to {@code LifecycleEvents.COMMANDS} handlers.
+ */
+public record CardboardCommandsEvent(Commands registrar, ReloadableRegistrarEvent.Cause cause)
+        implements ReloadableRegistrarEvent<Commands> {
+}

--- a/src/main/java/org/cardboardpowered/impl/command/MinecraftCommandWrapper.java
+++ b/src/main/java/org/cardboardpowered/impl/command/MinecraftCommandWrapper.java
@@ -64,8 +64,11 @@ public final class MinecraftCommandWrapper extends BukkitCommand {
     public static CommandSourceStack getCommandSource(CommandSender s) {
         if (s instanceof CraftPlayer)
             return ((CraftPlayer)s).getHandle().createCommandSourceStack();
-        if (s instanceof CraftEntity)
-            return ((CraftEntity)s).getHandle().createCommandSourceStackForNameResolution( (ServerLevel) ((CraftEntity)s).getWorld() );
+        if (s instanceof CraftEntity) {
+            // getWorld() is the Bukkit world, which is not a ServerLevel - take it off the handle.
+            net.minecraft.world.entity.Entity handle = ((CraftEntity) s).getHandle();
+            return handle.createCommandSourceStackForNameResolution((ServerLevel) handle.level());
+        }
         if (s instanceof ConsoleCommandSender)
             return ((CraftServer) s.getServer()).getServer().createCommandSourceStack();
 

--- a/src/main/java/org/cardboardpowered/mixin/commands/CommandSourceMixin.java
+++ b/src/main/java/org/cardboardpowered/mixin/commands/CommandSourceMixin.java
@@ -24,7 +24,11 @@ public interface CommandSourceMixin extends CommandSourceBridge {
 		}
 			
 		CommandSource output = source.source;
-		
+
+		// The console has no entity behind it, so it never reached the branches above.
+		if (output instanceof net.minecraft.server.MinecraftServer)
+			return org.bukkit.craftbukkit.CraftServer.INSTANCE.getConsoleSender();
+
 		// Memic Default Error
 		String msg1 = " does not define or inherit an implementation of the resolved method 'org.bukkit.command.CommandSender";
 		String msg2 = " getBukkitSender(net.minecraft.class_2168/ServerCommandSource)' of interface IMixinCommandOutput.";

--- a/src/main/java/org/cardboardpowered/mixin/commands/CommandSourceStackMixin.java
+++ b/src/main/java/org/cardboardpowered/mixin/commands/CommandSourceStackMixin.java
@@ -2,19 +2,75 @@ package org.cardboardpowered.mixin.commands;
 
 import net.minecraft.commands.CommandSource;
 import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.phys.Vec2;
+import net.minecraft.world.phys.Vec3;
+import org.bukkit.Location;
+import org.bukkit.craftbukkit.entity.CraftEntity;
 import org.cardboardpowered.bridge.commands.CommandSourceStackBridge;
+import org.cardboardpowered.bridge.world.entity.EntityBridge;
+import org.cardboardpowered.bridge.world.level.LevelBridge;
+import org.cardboardpowered.impl.world.CraftWorld;
 import org.spongepowered.asm.mixin.Mixin;
 import org.cardboardpowered.bridge.commands.CommandSourceBridge;
 import org.spongepowered.asm.mixin.Shadow;
 
+/**
+ * Also makes the vanilla source stack a Paper {@link io.papermc.paper.command.brigadier.CommandSourceStack},
+ * which is what lets plugin built Brigadier nodes run against the vanilla dispatcher.
+ */
 @Mixin(CommandSourceStack.class)
-public class CommandSourceStackMixin implements CommandSourceStackBridge {
+public abstract class CommandSourceStackMixin implements CommandSourceStackBridge, io.papermc.paper.command.brigadier.CommandSourceStack {
     @Shadow
     public CommandSource source;
+
+    @Shadow public abstract Vec3 getPosition();
+    @Shadow public abstract Vec2 getRotation();
+    @Shadow public abstract ServerLevel getLevel();
+    @Shadow public abstract net.minecraft.world.entity.Entity getEntity();
+    @Shadow public abstract CommandSourceStack withLevel(ServerLevel level);
+    @Shadow public abstract CommandSourceStack withPosition(Vec3 position);
+    @Shadow public abstract CommandSourceStack withRotation(Vec2 rotation);
+    @Shadow public abstract CommandSourceStack withEntity(net.minecraft.world.entity.Entity entity);
 
     // CraftBukkit start
     public org.bukkit.command.CommandSender getBukkitSender() {
         return ((CommandSourceBridge)this.source).getBukkitSender((CommandSourceStack)(Object)this);
     }
     // CraftBukkit end
+
+    @Override
+    public Location getLocation() {
+        Vec3 position = this.getPosition();
+        Vec2 rotation = this.getRotation();
+        return new Location(((LevelBridge)(Object) this.getLevel()).cardboard$getWorld(),
+                position.x, position.y, position.z, rotation.y, rotation.x);
+    }
+
+    @Override
+    public org.bukkit.command.CommandSender getSender() {
+        return this.getBukkitSender();
+    }
+
+    @Override
+    public org.bukkit.entity.Entity getExecutor() {
+        net.minecraft.world.entity.Entity entity = this.getEntity();
+        return (entity == null) ? null : ((EntityBridge)(Object) entity).getBukkitEntity();
+    }
+
+    @Override
+    public io.papermc.paper.command.brigadier.CommandSourceStack withLocation(Location location) {
+        CommandSourceStack moved = this.withPosition(new Vec3(location.getX(), location.getY(), location.getZ()))
+                .withRotation(new Vec2(location.getPitch(), location.getYaw()));
+
+        if (location.getWorld() != null)
+            moved = moved.withLevel(((CraftWorld) location.getWorld()).getHandle());
+
+        return (io.papermc.paper.command.brigadier.CommandSourceStack)(Object) moved;
+    }
+
+    @Override
+    public io.papermc.paper.command.brigadier.CommandSourceStack withExecutor(org.bukkit.entity.Entity executor) {
+        return (io.papermc.paper.command.brigadier.CommandSourceStack)(Object) this.withEntity(((CraftEntity) executor).getHandle());
+    }
 }

--- a/src/main/resources/META-INF/services/io.papermc.paper.plugin.lifecycle.event.types.LifecycleEventTypeProvider
+++ b/src/main/resources/META-INF/services/io.papermc.paper.plugin.lifecycle.event.types.LifecycleEventTypeProvider
@@ -1,0 +1,1 @@
+io.papermc.paper.plugin.lifecycle.event.types.CardboardLifecycleEventTypeProvider


### PR DESCRIPTION
### The problem

Cardboard ships its own `org.bukkit.plugin.java.JavaPlugin` in place of Paper's, and it never implemented `getLifecycleManager()` — which `org.bukkit.plugin.Plugin` declares abstract. Since that is the standard way to register Brigadier commands on Paper, plugins that use it die on enable:

```
[Server thread/ERROR]: Error occurred while enabling UJobs v1.0.8 (Error)
java.lang.AbstractMethodError: Method me/usainsrht/ujobs/UJobsPlugin.getLifecycleManager()Lio/papermc/paper/plugin/lifecycle/event/LifecycleEventManager; is abstract
	at me.usainsrht.ujobs.UJobsPlugin.registerEventsAndCommands(UJobsPlugin.java:183)
	at me.usainsrht.ujobs.UJobsPlugin.onEnable(UJobsPlugin.java:67)
```

Adding the method alone would only trade the crash for silence: no `LifecycleEventTypeProvider` was registered, so merely touching `LifecycleEvents` failed to initialise the class, and `PaperLifecycleEventManager.registerEventHandler` had its body commented out and dropped every registration. This implements the whole path so the plugins actually work.

### What this adds

- A `LifecycleEventTypeProvider` service backing the prioritized and monitor event types. Handlers are kept per owner and run in priority order with monitors last; a handler that throws is logged against its own plugin and does not stop the others. Tag events are handed out but never fire, since Cardboard does not run plugin bootstrap — that is better than failing class initialisation.
- Real handler registration, plus dropping an owner's handlers when it is disabled, so `/reload` does not run them twice.
- `JavaPlugin.getLifecycleManager()`, with registration allowed while the plugin loads or enables, matching Paper.
- `Commands`: a plugin's `LiteralCommandNode` goes into the vanilla dispatcher **and** into the Bukkit command map, which is what gives it a namespaced alias, help entry and tab completion, and what gets it grafted into the dispatcher `syncCommands()` rebuilds afterwards. `BasicCommand` is supported through a greedy string node. `LifecycleEvents.COMMANDS` fires once the vanilla commands are in the command map but before it is synced.
- The vanilla `CommandSourceStack` now implements the Paper `CommandSourceStack`. That is the trick that lets a node built against the Paper source type execute on the vanilla dispatcher, and it gives plugins `getSender()`, `getLocation()` and `getExecutor()`.

Two existing gaps sit directly on this path and are fixed here too:

- `CommandSource.getBukkitSender` mapped only players and entities, and threw `AbstractMethodError` for the console — so any plugin command run from the console failed.
- `MinecraftCommandWrapper.getCommandSource` cast a Bukkit `World` to a `ServerLevel`, so a non-player entity running any wrapped command hit a `ClassCastException`.

### Testing

`./gradlew compileJava` passes on both `ver/1.21.11` and `ver/26.1`.

Verified end to end on a real server (`./gradlew runServer`) with a test plugin that registers through `getLifecycleManager().registerEventHandler(LifecycleEvents.COMMANDS, ...)` exactly the way UJobs does — a Brigadier node with a literal, an argument child and an alias, plus a `BasicCommand`:

- the `COMMANDS` event fires with `cause=INITIAL` and registration succeeds;
- from the console: the literal, the argument child, the alias and the `<plugin>:<label>` form all execute, and `BasicCommand` receives its arguments (`args=[one, two]`) and the empty case;
- through `CraftServer.dispatchCommand`'s entity branch — the same code a player's command packet takes with `registry-command-fix` on — the literal, alias, namespaced and `BasicCommand` forms all return `true` and run;
- `getExecutor()` and `getLocation()` return the right entity and location.

Not covered: an actual connected client, so the command tree sent to players and in-game tab completion are reasoned about rather than observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
