### PR TITLE
fix: stop baby hostile mobs dropping no loot at all (1.21.11)

### DIFF
--- a/src/main/java/org/cardboardpowered/mixin/world/entity/LivingEntityMixin.java
+++ b/src/main/java/org/cardboardpowered/mixin/world/entity/LivingEntityMixin.java
@@ -98,7 +98,9 @@ public abstract class LivingEntityMixin extends EntityMixin implements LivingEnt
 
         boolean flag = get().lastHurtByPlayerMemoryTime > 0;
         this.dropEquipment(world);
-        if (!get().isBaby() && world.getGameRules().get(GameRules.MOB_DROPS)) {
+        // Ask the entity itself: LivingEntity's own answer excludes babies, but Monster overrides
+        // that away, so inlining the base check silently drops all loot from every baby hostile.
+        if (this.shouldDropLoot(world)) {
             this.dropFromLootTable(world, damagesource, flag);
             this.dropCustomDeathLoot((ServerLevel) world, damagesource, flag);
         }
@@ -148,6 +150,9 @@ public abstract class LivingEntityMixin extends EntityMixin implements LivingEnt
     public void pushEffectCause(EntityPotionEffectEvent.Cause cause) {
         bukkitCause = cause;
     }
+
+    @Shadow
+    protected abstract boolean shouldDropLoot(ServerLevel world);
 
     @Shadow
     public void dropFromLootTable(ServerLevel world, DamageSource damagesource, boolean flag) {


### PR DESCRIPTION
### The problem

Baby hostile mobs drop nothing on Cardboard. That includes the **Lava Chicken** music disc from a chicken jockey, which is what led me here — the disc's loot pool lives in `zombie.json` and requires the rider to be a baby that is still riding a chicken:

```json
"conditions": [
  { "condition": "minecraft:killed_by_player" },
  { "condition": "minecraft:entity_properties", "entity": "this",
    "predicate": { "flags": { "is_baby": true }, "vehicle": { "type": "minecraft:chicken" } } }
]
```

`LivingEntityMixin` overwrites `dropAllDeathLoot` to fire `EntityDeathEvent`, and while doing so it inlined the loot gate as:

```java
if (!get().isBaby() && world.getGameRules().get(GameRules.MOB_DROPS)) {
```

That is a faithful copy of `LivingEntity.shouldDropLoot` — but `shouldDropLoot` is virtual, and `Monster` overrides it to keep only the gamerule check:

```
protected boolean shouldDropLoot(ServerLevel);
  Code:
       0: aload_1
       1: invokevirtual  ServerLevel.getGameRules()
       ...
      16: ireturn        // no isBaby() anywhere
```

Inlining the base version bypasses that override, so every baby hostile is silently excluded from its loot table: no rotten flesh from baby zombies, husks, drowned or zombie villagers, no gold nuggets/ingots from baby zombified piglins, and no Lava Chicken disc.

### The fix

Call the virtual `this.shouldDropLoot(world)` and let the entity's own override decide. One line, plus the `@Shadow` for it.

### Testing

Measured on a real server (`./gradlew runServer`) with a plugin that kills 40 adult and 40 baby zombies the same way and sums the `EntityDeathEvent` drops — the counts are needed because rotten flesh is a 0–2 roll, so a single kill proves nothing:

| | adult items | baby items |
|---|---|---|
| before | 32 | **0** |
| after | 35 | **41** |

Adults are unaffected; babies go from never dropping to matching adults, as they should.

Also confirmed the chicken jockey keeps its chicken as `getVehicle()` at the moment the rider dies, so the pool's `vehicle` predicate is satisfiable. Not covered: the disc drop end to end, since the pool also requires `killed_by_player` and the harness has no connected client — that half is unchanged by this patch either way.
